### PR TITLE
Querystring parameters that doesn't belong to the model

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -57,24 +57,26 @@ var restify = function(app, model, options) {
 		delete options.populate;
 		
 		for(var key in options) {
-			query.where(key);
+			if(model.schema.paths.hasOwnProperty(key)) {
+				query.where(key);
 
-			var value = options[key];
-			if('>' == value[0]) {
-				if('=' == value[1]) {
-					query.gte(value.substr(2));
-				} else {
-					query.gt(value.substr(1));
+				var value = options[key];
+				if('>' == value[0]) {
+					if('=' == value[1]) {
+						query.gte(value.substr(2));
+					} else {
+						query.gt(value.substr(1));
+					}
 				}
-			}
-			else if('<' == value[0]) {
-				if('=' == value[1]) {
-					query.lte(value.substr(2));
+				else if('<' == value[0]) {
+					if('=' == value[1]) {
+						query.lte(value.substr(2));
+					} else {
+						query.lt(value.substr(1));
+					}
 				} else {
-					query.lt(value.substr(1));
+					query.equals(value);
 				}
-			} else {
-				query.equals(value);
 			}
 		}
 		


### PR DESCRIPTION
When dealing with API calls sometimes we want to let the browser decide whether to respond a request with a cached response or make a new request. Some other times we want to explicit the disable cache parameter. This parameter is added to the querystring like "_dc=1300243558614".

There is a problem when the express-restify-mongoose module receives parameters like these. When the query of the mongoose model is built, this parameter will be treated as a restriction but it is not a restriction. For that reason I added a condition on the buildQuery method that adds the parameter to the query only if it's a property of the schema.
