### PR TITLE
cleanQuery method before the middleware is called

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -38,10 +38,10 @@ var restify = function(app, model, options) {
 			var m = options.middleware;
 			options.middleware = [ m ];
 		}
-        options.middleware.unshift(cleanQuery);
 	} else {
 		options.middleware = [];
 	}
+    options.middleware.unshift(cleanQuery);
 
     var queryOptions = {protected: ["skip", "limit", "sort", "populate"], current: {}};
 	
@@ -49,7 +49,7 @@ var restify = function(app, model, options) {
 	var uri_item = util.format('%s%s/%ss/:id', options.prefix, options.version, model.modelName);
 
     function cleanQuery(req, res, next) {
-		queryOptions.current = {};
+        queryOptions.current = {};
         for(var key in req.query) {
             if(!model.schema.paths.hasOwnProperty(key)) {
                 if(queryOptions.protected.indexOf(key) != -1) {


### PR DESCRIPTION
The part on the buildQuery method that cleans the querystring from parameters that doesn't belong to the model has been moved to the first position of the middleware. This is to permit modification of the querystring in the middleware functions in case of user scope restrictions or other.

Now, if I want to modify the query in the middleware I can add objects to "req.query".
