### PR TITLE
added option for pluralizing the route -- quite helpful if your schema is already plural, cheers

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -30,13 +30,13 @@ var restify = function(app, model, options) {
 	if(!options.prefix) {
 		options.prefix = "/api";
 	}
-  if( ( typeof(options.plural) === "undefined" ) || ( options.plural === null ) ) {
-    options.plural = true
-  }
+	if(!options.plural) {
+	    	options.plural = true
+	}
 	if(!options.version) {
 		options.version = "/v1";
 	}
-	if(options.middleware) {
+  if(options.middleware) {
 		if(!options.middleware instanceof Array) {
 			var m = options.middleware;
 			options.middleware = [ m ];
@@ -50,8 +50,8 @@ var restify = function(app, model, options) {
 
     var apiUri = options.plural === true ? "%s%s/%ss" : "%s%s/%s"
 	
-  	var uri_items = util.format(apiUri, options.prefix, options.version, model.modelName);
-  	var uri_item = util.format(apiUri + '/:id', options.prefix, options.version, model.modelName);
+    var uri_items = util.format(apiUri, options.prefix, options.version, model.modelName);
+    var uri_item = util.format(apiUri + '/:id', options.prefix, options.version, model.modelName);
 
     function cleanQuery(req, res, next) {
         queryOptions.current = {};


### PR DESCRIPTION
allows you to pass in `{plural: True || False}` into the options object, defaults to `true` as original design pluralized collections automatically
