### PR TITLE
added option for pluralizing the route -- quite helpful if your schema is already plural, cheers

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -30,9 +30,9 @@ var restify = function(app, model, options) {
 	if(!options.prefix) {
 		options.prefix = "/api";
 	}
-	if(!options.plural) {
-	    	options.plural = true
-	}
+  if( ( typeof options.plural === "undefined" ) || ( options.plural === null ) ) {
+    options.plural = true
+  }
 	if(!options.version) {
 		options.version = "/v1";
 	}
@@ -50,8 +50,8 @@ var restify = function(app, model, options) {
 
     var apiUri = options.plural === true ? "%s%s/%ss" : "%s%s/%s"
 	
-    var uri_items = util.format(apiUri, options.prefix, options.version, model.modelName);
-    var uri_item = util.format(apiUri + '/:id', options.prefix, options.version, model.modelName);
+  	var uri_items = util.format(apiUri, options.prefix, options.version, model.modelName);
+  	var uri_item = util.format(apiUri + '/:id', options.prefix, options.version, model.modelName);
 
     function cleanQuery(req, res, next) {
         queryOptions.current = {};


### PR DESCRIPTION
Had to recommit, see log -- silly me.

Added `options.plural` - Boolean

Cheers,

see this line: `var apiUri = options.plural === true ? "%s%s/%ss" : "%s%s/%s"`
