### PR TITLE
Added RegExp support for querying database keys.  

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -20,172 +20,174 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
-**/
-var util = require('util');
+ **/
+ var util = require('util');
 
-var restify = function(app, model, options) {
-	if(!options) {
-		options = { };
-	}
-	if(!options.prefix) {
-		options.prefix = "/api";
-	}
-  if( ( typeof options.plural === "undefined" ) || ( options.plural === null ) ) {
-    options.plural = true
-  }
-	if(!options.version) {
-		options.version = "/v1";
-	}
-  if(options.middleware) {
-		if(!options.middleware instanceof Array) {
-			var m = options.middleware;
-			options.middleware = [ m ];
-		}
-	} else {
-		options.middleware = [];
-	}
-    options.middleware.unshift(cleanQuery);
+ var restify = function(app, model, options) {
+ 	if(!options) {
+ 		options = { };
+ 	}
+ 	if(!options.prefix) {
+ 		options.prefix = "/api";
+ 	}
+ 	if( ( typeof options.plural === "undefined" ) || ( options.plural === null ) ) {
+ 		options.plural = true
+ 	}
+ 	if(!options.version) {
+ 		options.version = "/v1";
+ 	}
+ 	if(options.middleware) {
+ 		if(!options.middleware instanceof Array) {
+ 			var m = options.middleware;
+ 			options.middleware = [ m ];
+ 		}
+ 	} else {
+ 		options.middleware = [];
+ 	}
+ 	options.middleware.unshift(cleanQuery);
 
-    var queryOptions = {protected: ["skip", "limit", "sort", "populate"], current: {}};
+ 	var queryOptions = {protected: ["skip", "limit", "sort", "populate"], current: {}};
 
-    var apiUri = options.plural === true ? "%s%s/%ss" : "%s%s/%s"
-	
-  	var uri_items = util.format(apiUri, options.prefix, options.version, model.modelName);
-  	var uri_item = util.format(apiUri + '/:id', options.prefix, options.version, model.modelName);
+ 	var apiUri = options.plural === true ? "%s%s/%ss" : "%s%s/%s"
 
-    function cleanQuery(req, res, next) {
-        queryOptions.current = {};
-        for(var key in req.query) {
-            if(!model.schema.paths.hasOwnProperty(key)) {
-                if(queryOptions.protected.indexOf(key) != -1) {
-                    queryOptions.current[key] = req.query[key];
-                }
-                delete req.query[key];
-            }
-        }
-        next();
-    }
+ 	var uri_items = util.format(apiUri, options.prefix, options.version, model.modelName);
+ 	var uri_item = util.format(apiUri + '/:id', options.prefix, options.version, model.modelName);
 
-	function buildQuery(query, options) {
-		for(var key in options) {
-            query.where(key);
+ 	function cleanQuery(req, res, next) {
+ 		queryOptions.current = {};
+ 		for(var key in req.query) {
+ 			if(!model.schema.paths.hasOwnProperty(key)) {
+ 				if(queryOptions.protected.indexOf(key) != -1) {
+ 					queryOptions.current[key] = req.query[key];
+ 				}
+ 				delete req.query[key];
+ 			}
+ 		}
+ 		next();
+ 	}
 
-            var value = options[key];
-            if('>' == value[0]) {
-                if('=' == value[1]) {
-                    query.gte(value.substr(2));
-                } else {
-                    query.gt(value.substr(1));
-                }
-            }
-            else if('<' == value[0]) {
-                if('=' == value[1]) {
-                    query.lte(value.substr(2));
-                } else {
-                    query.lt(value.substr(1));
-                }
-            } else {
-                query.equals(value);
-            }
-		}
-		
-		if(queryOptions.current.skip) {
-			query.skip(queryOptions.current.skip);
-		}
-		if(queryOptions.current.limit) {
-			query.limit(queryOptions.current.limit);
-		}
-		if(queryOptions.current.sort) {
-			query.sort(queryOptions.current.sort);
-		}
-		if(queryOptions.current.populate) {
-			var arr = queryOptions.current.populate.split(',');
-			for(var i = 0; i < arr.length; ++i) {
-				query = query.populate(arr[i]);
-			}
-		}
-		
-		return query;
-	}
-	
-	function ensureContentType(req, res, next) {
-		var ct = req.get('Content-Type');
-		if(-1 == ct.indexOf('application/json')) {
-			res.send(400, 'Bad request');
-		} else {
-			next();
-		}
-	}
-	function createObject(req, res) {
-		model.create(req.body, function(err, item) {
-			if(err) {
-				res.send(400, 'Bad request');
-			} else {
-				res.type('json');
-				res.send(JSON.stringify(item));
-			}
-		});
-	}
-	function modifyObject(req, res) {
-		delete req.body._id;
-		delete req.body.__v;
+ 	function buildQuery(query, options) {
+ 		for(var key in options) {
+ 			query.where(key);
+ 			var value = options[key];
 
-		model.findOneAndUpdate({ _id: res.req.param('id') }, req.body, {}, function(err, item) {
-			if(err) {
-				console.log(err);
-				res.send(404, 'Not found');
-			} else {
-				res.type('json');
-				res.send(JSON.stringify(item));
-			}
-		});
-	}
-	
-	var write_middleware = options.middleware.slice(0);
-	write_middleware.push(ensureContentType);
-	
-	app.get(uri_items, options.middleware, function(req, res) {
-        buildQuery(model.find(), req.query).exec(function(err, items) {
-			if(err) {
-				res.send(400, 'Bad request');
-			} else {
-				res.type('json');
-				res.send(JSON.stringify(items));
-			}
-		});
-	});
-	app.post(uri_items, write_middleware, createObject);
-	app.put(uri_items, write_middleware, createObject);
-	app.delete(uri_items, options.middleware, function(req, res) {
-		buildQuery(model.find(), req.query).remove(function(err) {
-			if(err) {
-				res.send(400, 'Bad request');
-			} else {
-				res.send(200, 'Ok');
-			}
-		});
-	});
-	app.get(uri_item, options.middleware, function(req, res) {
-		buildQuery(model.findById(res.req.param('id')), req.query).findOne(function(err, item) {
-			if(err) {
-				res.send(404, 'Not found');
-			} else {
-				res.type('json');
-				res.send(JSON.stringify(item));
-			}
-		});
-	});
-	app.post(uri_item, write_middleware, modifyObject);
-	app.put(uri_item, write_middleware, modifyObject);
-	app.delete(uri_item, options.middleware, function(req, res) {
-		model.remove({ _id: res.req.param('id') }, function(err) {
-			if(err) {
-				res.send(404, 'Not found');
-			} else {
-				res.send(200, 'Ok');
-			}
-		});
-	});
-};
+ 			if('~' == value[0]) {
+				re = new RegExp(value.substring(1), 'i'); 
+				query.where(key).regex(re);
+ 			} else if('>' == value[0]) {
+ 				if('=' == value[1]) {
+ 					query.gte(value.substr(2));
+ 				} else {
+ 					query.gt(value.substr(1));
+ 				}
+ 			} else if('<' == value[0]) {
+ 				if('=' == value[1]) {
+ 					query.lte(value.substr(2));
+ 				} else {
+ 					query.lt(value.substr(1));
+ 				}
+ 			} else {
+ 				query.equals(value);
+ 			}
+ 		}
 
-module.exports.serve = restify;
+ 		if(queryOptions.current.skip) {
+ 			query.skip(queryOptions.current.skip);
+ 		}
+ 		if(queryOptions.current.limit) {
+ 			query.limit(queryOptions.current.limit);
+ 		}
+ 		if(queryOptions.current.sort) {
+ 			query.sort(queryOptions.current.sort);
+ 		}
+ 		if(queryOptions.current.populate) {
+ 			var arr = queryOptions.current.populate.split(',');
+ 			for(var i = 0; i < arr.length; ++i) {
+ 				query = query.populate(arr[i]);
+ 			}
+ 		}
+
+ 		return query;
+ 	}
+
+ 	function ensureContentType(req, res, next) {
+ 		var ct = req.get('Content-Type');
+ 		if(-1 == ct.indexOf('application/json')) {
+ 			res.send(400, 'Bad request');
+ 		} else {
+ 			next();
+ 		}
+ 	}
+ 	function createObject(req, res) {
+ 		model.create(req.body, function(err, item) {
+ 			if(err) {
+ 				res.send(400, 'Bad request');
+ 			} else {
+ 				res.type('json');
+ 				res.send(JSON.stringify(item));
+ 			}
+ 		});
+ 	}
+ 	function modifyObject(req, res) {
+ 		delete req.body._id;
+ 		delete req.body.__v;
+
+ 		model.findOneAndUpdate({ _id: res.req.param('id') }, req.body, {}, function(err, item) {
+ 			if(err) {
+ 				console.log(err);
+ 				res.send(404, 'Not found');
+ 			} else {
+ 				res.type('json');
+ 				res.send(JSON.stringify(item));
+ 			}
+ 		});
+ 	}
+
+ 	var write_middleware = options.middleware.slice(0);
+ 	write_middleware.push(ensureContentType);
+
+ 	app.get(uri_items, options.middleware, function(req, res) {
+ 		buildQuery(model.find(), req.query).exec(function(err, items) {
+ 			if(err) {
+ 				res.send(400, 'Bad request');
+ 			} else {
+ 				res.type('json');
+ 				res.send(JSON.stringify(items));
+ 			}
+ 		});
+ 	});
+ 	app.post(uri_items, write_middleware, createObject);
+ 	app.put(uri_items, write_middleware, createObject);
+ 	app.delete(uri_items, options.middleware, function(req, res) {
+ 		buildQuery(model.find(), req.query).remove(function(err) {
+ 			if(err) {
+ 				res.send(400, 'Bad request');
+ 			} else {
+ 				res.send(200, 'Ok');
+ 			}
+ 		});
+ 	});
+ 	app.get(uri_item, options.middleware, function(req, res) {
+ 		buildQuery(model.findById(res.req.param('id')), req.query).findOne(function(err, item) {
+ 			if(err) {
+ 				res.send(404, 'Not found');
+ 			} else {
+ 				res.type('json');
+ 				res.send(JSON.stringify(item));
+ 			}
+ 		});
+ 	});
+ 	app.post(uri_item, write_middleware, modifyObject);
+ 	app.put(uri_item, write_middleware, modifyObject);
+ 	app.delete(uri_item, options.middleware, function(req, res) {
+ 		model.remove({ _id: res.req.param('id') }, function(err) {
+ 			if(err) {
+ 				res.send(404, 'Not found');
+ 			} else {
+ 				res.send(200, 'Ok');
+ 			}
+ 		});
+ 	});
+ };
+
+ module.exports.serve = restify;


### PR DESCRIPTION
It's just a couple lines but they've proven rather helpful on my end.  I have implemented this with a '~' trigger: 

http://localhost:3000/api/v1/somecollection/somefieldname=~myregex

Have a good day.  
