### PR TITLE
Added option for excluding fields through options on the server side.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ serve(app, model, [options])
   * version - An API version that will be prefixed to the rest path. Defaults to ```v1```
   * middleware - An express middleware or an array of express middlewares that will be used.
   * plural - If ```true```, does not pluralize the database model name. Default is ```false```
+  * exclude - Object of fields to exclude, handled server side. Defaults to display all fields 
   
 ## Contributors
 * Enric León (https://github.com/nothingbuttumbleweed)

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -24,6 +24,8 @@
 var util = require('util');
 
 var restify = function(app, model, options) {
+    var fieldsToHide = null
+
  	if(!options) {
  		options = { };
  	}
@@ -36,6 +38,9 @@ var restify = function(app, model, options) {
  	if(!options.version) {
  		options.version = "/v1";
  	}
+    if(options.exclude) {
+      fieldsToHide = options.exclude
+    }
  	if(options.middleware) {
  		if(!options.middleware instanceof Array) {
  			var m = options.middleware;
@@ -97,6 +102,9 @@ var restify = function(app, model, options) {
  		if(queryOptions.current.limit) {
  			query.limit(queryOptions.current.limit);
  		}
+    if(fieldsToHide !== null) {
+        query.select(fieldsToHide);
+    }        
  		if(queryOptions.current.sort) {
  			query.sort(queryOptions.current.sort);
  		}


### PR DESCRIPTION
Helpful if you like to exclude sensitive fields from your public API

Example usage would be:

``` js
var User = require("../../models/user");

var express = require("express")
var app = module.exports = express()

var restify = require("express-restify-mongoose");

restify.serve(app, User, {
  prefix: "/api",
  exclude: {password: 0, _id: 0, email: 0, ip: 0}
});
```

Cheers!
