### PR TITLE
Previous check for restify vs express was failing when serving more than...

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -108,14 +108,8 @@ var restify = function (app, model, options) {
 
     options.middleware.unshift(cleanQuery);
     
-    var outputFn = outputExpress;
-
-    // Support restify vs express
-    if (!app.delete && app.del) {
-        // TODO: find a better way to make this determination
-        outputFn = outputRestify;
-        app.delete = app.del;
-    }
+    var outputFn = options.restify ? outputRestify : outputExpress;
+    app.delete = app.del;
 
     var apiUri = options.plural === true ? '%s%s/%ss' : '%s%s/%s';
 

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,7 @@ function Express() {
 function Restify() {
     var app = restify.createServer();
     app.use(restify.bodyParser());
+    app.isRestify = true;
     return app;
 }
 
@@ -36,7 +37,7 @@ function Restify() {
             setup();
 
             before(function (done) {
-                erm.serve(app, setup.customerModel);
+                erm.serve(app, setup.customerModel, { restify: app.isRestify });
                 server = app.listen(testPort, done);
             });
 
@@ -154,7 +155,8 @@ function Restify() {
 
             before(function (done) {
                 erm.serve(app, setup.customerModel, {
-                    exclude: 'comment'
+                    exclude: 'comment',
+                    restify: app.isRestify
                 });
                 server = app.listen(testPort, function () {
                     request.post({


### PR DESCRIPTION
... one model.  Make using restify explicit, since its support is secondary.
