### PR TITLE
Return mongoosejs error as JSON, check if PUT/POST'ed properties exist in the model

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -211,7 +211,9 @@ var restify = function (app, model, options) {
         } else {
             for (key in req.body) {
                 path = model.schema.path(key);
-                if(typeof path === "undefined") continue;
+                if (typeof path === 'undefined') {
+                    continue;
+                }
                 if ((path.instance === 'ObjectID') &&
                     (typeof req.body[key] === 'object')) {
                     req.body[key] = req.body[key]._id;
@@ -255,7 +257,9 @@ var restify = function (app, model, options) {
 
         for (var key in req.body) {
             var path = model.schema.path(key);
-            if(typeof path === "undefined") continue;
+            if (typeof path === 'undefined') {
+                continue;
+            }
             if ((path.instance === 'ObjectID') &&
                (typeof req.body[key] === 'object')) {
                 req.body[key] = req.body[key]._id;


### PR DESCRIPTION
Thanks for this very nice project.
I just found it today, so please consider my change a proposal, I might have missed some places regarding validation.

I propose the following that allows clients to handle validation errors appropriately.
Maybe this could be of some help to others as well.

Regarding posting/putting properties that do not exist in the model, the following error happened:

```
TypeError: Cannot read property 'instance' of undefined
    at modifyObject (/Users/michael/code/node_modules/express-restify-mongoose/lib/express-restify-mongoose.js:258:22)
    at callbacks (/Users/michael/code/node_modules/express/lib/router/index.js:164:37)
    at ensureContentType (/Users/michael/code/node_modules/express-restify-mongoose/lib/express-restify-mongoose.js:189:13)
    at callbacks (/Users/michael/code/node_modules/express/lib/router/index.js:164:37)
    at cleanQuery (/Users/michael/code/node_modules/express-restify-mongoose/lib/express-restify-mongoose.js:102:9)
    at callbacks (/Users/michael/code/node_modules/express/lib/router/index.js:164:37)
    at param (/Users/michael/code/node_modules/express/lib/router/index.js:138:11)
    at param (/Users/michael/code/node_modules/express/lib/router/index.js:135:11)
    at pass (/Users/michael/code/node_modules/express/lib/router/index.js:145:5)
    at Router._dispatch (/Users/michael/code/node_modules/express/lib/router/index.js:173:5)
```
