### PR TITLE
Adds robust exclude support

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -66,7 +66,7 @@ var restify = function (app, model, opts) {
 
     exclude = options.exclude;
     lean = options.lean;
-    filter = new Filter(model, exclude, lean);
+    filter = new Filter(model, exclude);
     postProcess = options.postProcess || function () {};
 
     if (options.middleware) {

--- a/lib/resource_filter.js
+++ b/lib/resource_filter.js
@@ -14,7 +14,7 @@ var util = require('util'),
         return arr.filter(filterFn(head)).map(mapFn(head));
     };
 
-module.exports = function (model, excludedKeys, lean) {
+module.exports = function (model, excludedKeys) {
     excludedKeys = excludedKeys || '';
     excludedMap[model.modelName] = excludedKeys;
 


### PR DESCRIPTION
This request will exclude the appropriate fields from embedded documents/document arrays, and populated documents. The exclude syntax remains the same, except delving into objects with dot notation (e.g. exclude='customer.purchases') is supported.

This was much more complicated than i originally thought, so there may be some edge cases I haven't covered. Not sure how to update the Readme, as the feature is pretty much the same, but better!
