### PR TITLE
fix non array middleware option

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -79,7 +79,7 @@ var restify = function (app, model, opts) {
     postProcess = options.postProcess || function () {};
 
     if (options.middleware) {
-        if (!options.middleware instanceof Array) {
+        if (!(options.middleware instanceof Array)) {
             var m = options.middleware;
             options.middleware = [ m ];
         }


### PR DESCRIPTION
Passing a middleware as a non array didn't work due to wrong comparison in instanceof check
