### PR TITLE
fix copy of array options

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -62,7 +62,13 @@ var restify = function (app, model, opts) {
         };
 
     for (var prop in opts) {
-        options[prop] = opts[prop];
+        if (opts[prop] instanceof Array ) {
+            options[prop] = [];
+            for ( index in opts[prop] ) {
+                options[prop][index] = opts[prop][index];
+            }
+        } else
+            options[prop] = opts[prop];
     }
 
     options.private = options.private ? options.private.split(',') : [];


### PR DESCRIPTION
The previous code copied arrays in the option object by reference.
This was modifying the original arrays. In case of a passed middleware array, 
this lead to multiple calls of cleanQuery if e-r-m was called on multiple models 
with the same option object.
