### PR TITLE
logical operators $and, $or to improve query capabilities with Mongoose

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,14 @@ GET http://localhost/api/v1/Customers?name=>value
 GET http://localhost/api/v1/Customers?name=>=value
 GET http://localhost/api/v1/Customers?name=<value
 GET http://localhost/api/v1/Customers?name=<=value
+GET http://localhost/api/v1/Customers?name=!=value
 GET http://localhost/api/v1/Customers?select=name
+```
+
+## Logical Queries (and,or)
+```
+GET http://localhost/api/v1/Customers?$and[{"field":">=value"},{"field":[value1,value2]}]
+GET http://localhost/api/v1/Customers?$or[{"field":"value"},{"$and",[{"field":"~value"},{"field":"!=value"}]}]
 ```
 
 ### Ordering & Sorting

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -60,7 +60,8 @@ var restify = function (app, model, opts) {
         usingExpress = true,
         options = getDefaults(),
         queryOptions = {
-            protected: ['skip', 'limit', 'sort', 'populate', 'select', 'lean'],
+            protected: ['skip', 'limit', 'sort', 'populate', 'select', 'lean',
+                        '$and', '$or'],//H+ exposes query OR and AND methods
             current: {}
         };
 
@@ -155,12 +156,24 @@ var restify = function (app, model, opts) {
                 } else {
                     query.lt(value.substr(1));
                 }
+            } else if ('!' === value[0] && '=' === value[1]) { //H+ for !=
+                query.ne(value.substr(2));
             } else if ('[' === value[0] && ']' === value[value.length - 1]) {
                 query.in(value.substr(1, value.length - 2).split(','));
             } else {
                 query.equals(value);
             }
         }
+
+        //H+ exposes Query AND, OR methods
+        //TODO - add support for more logical operators supported by Mongoose
+        if (queryOptions.current.$and) {
+            query.and(JSON.parse(queryOptions.current.$and, JSONReviewer));
+        }
+        if (queryOptions.current.$or) {
+            query.or(JSON.parse(queryOptions.current.$or, JSONReviewer));
+        }
+        //H+ exposes Query AND, OR methods
 
         if (queryOptions.current.skip) {
             query.skip(queryOptions.current.skip);
@@ -204,6 +217,36 @@ var restify = function (app, model, opts) {
         }
         return query;
     }
+
+    //H+ - JSON query param parser
+    //TODO - improve to serve recursive logical operators
+    function JSONReviewer(key, value) {
+        if (_.isString(value)) {
+            if ('~' === value[0]) { //parse RegExp
+                return new RegExp(value.substring(1), 'i');
+            } else if ('>' === value[0]) {
+                if ('=' === value[1]) {
+                    return {$gte: value.substr(2)};
+                } else {
+                    return {$gt: value.substr(1)};
+                }
+            } else if ('<' === value[0]) {
+                if ('=' === value[1]) {
+                    return {$lte: value.substr(2)};
+                } else {
+                    return {$lt: value.substr(1)};
+                }
+            } else if ('!' === value[0] && '=' === value[1]) {
+                return {$ne: value.substr(2)};
+            }
+        } else if (_.isArray(value)) {
+            if (model.schema.paths.hasOwnProperty(key)) {
+                return {$in: value};
+            }
+        }
+        return value;
+    }
+    //H+ - JSON query param parser
 
     function ensureContentType(req, res, next) {
         var ct = req.headers['content-type'];

--- a/test/test.js
+++ b/test/test.js
@@ -368,18 +368,49 @@ function Restify() {
                     });
                 });
 
-                it('200 GET Customers?name=Test', function (done) {
+                it('200 GET Customers?name!=Test', function (done) {
                     request.get({
                         url: util.format('%s/api/v1/Customers', testUrl),
                         qs: {
-                            name: 'Test'
+                            name: '!=Test'
                         },
                         json: true
                     }, function (err, res, body) {
                         assert.equal(res.statusCode, 200, 'Wrong status code');
-                        assert.equal(body.length, 1,
+                        assert.equal(body.length, 2,
                             'Wrong count of customers returned');
-                        assert.deepEqual(savedCustomer, body[0]);
+                        done();
+                    });
+                });
+
+                it('200 GET Products?$and[?]', function (done) {
+                    request.get({
+                        url: util.format('%s/api/v1/Products?$and=%s',
+                            testUrl,
+                            '[{"name":"~ACME"},{"price":"!=20"}]'),
+                        json: true
+                    }, function (err, res, body) {
+                        assert.equal(res.statusCode, 200, 'Wrong status code');
+                        assert.equal(body.length, 2,
+                            'Wrong count of customers returned');
+                        console.log(JSON.stringify(body));
+                        done();
+                    });
+                });
+
+                it('200 GET Products?$or[$and[?]]', function (done) {
+                    request.get({
+                        url: util.format('%s/api/v1/Products?$or=%s',
+                            testUrl,
+                            '[{"name":"~Another"},' +
+                                '{"$and":[{"name":"~Product"},' +
+                                        '{"price":"<=10"}]}]'),
+                        json: true
+                    }, function (err, res, body) {
+                        assert.equal(res.statusCode, 200, 'Wrong status code');
+                        assert.equal(body.length, 4,
+                            'Wrong count of customers returned');
+                        console.log(JSON.stringify(body));
                         done();
                     });
                 });


### PR DESCRIPTION
Added support for $and, $or query options to improve Query possibilities over HTTP.

```
GET http://localhost/api/v1/Customers?$and[{"field":">=value"},{"field":[value1,value2]}]
GET http://localhost/api/v1/Customers?$or[{"field":"value"},{"$and",[{"field":"~value"},{"field":"!=value"}]}]
```

which will transform as

```
Customer.find()
        .or([
            {field: 'value'},
            {"$and":[
                      {"field" : { $ne : value } }
                ]}
        ])
        .exec(function (err, res) {
            if (err) {
                done(err);
            } else {
                console.log(res);
            }
            done();
        });
```

Also added != operation for normal conditions

```
GET http://localhost/api/v1/Customers?name=!=value
```

Any improvements/suggestions/modifications are welcome.
