### PR TITLE
Added query Parameter to pass all mongoose Query options with URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,28 @@ GET http://localhost/api/v1/Customers?name=<=value
 GET http://localhost/api/v1/Customers?name=!=value
 GET http://localhost/api/v1/Customers?select=name
 ```
-
+## Mongoose Query
+```
+var query = { $or: [
+                {name: '~Another'},
+                {$and: [
+                    {name: '~Product'},
+                    {price: '<=10'}
+                ]}
+            ],
+                price: 20
+            };
+request({
+    url: 'api/v1/Model',
+    qs: { query: encodeURIComponent(JSON.stringify(query) }
+})
+GET http://localhost/api/v1/Customers?query={"field":">=value", "field":[value1,value2]
+                                                 "$and":[{"field":"~value"},{"field":"!=value"}]}
+```
 ## Logical Queries (and,or)
 ```
-GET http://localhost/api/v1/Customers?$and[{"field":">=value"},{"field":[value1,value2]}]
-GET http://localhost/api/v1/Customers?$or[{"field":"value"},{"$and",[{"field":"~value"},{"field":"!=value"}]}]
+GET http://localhost/api/v1/Customers?$and=[{"field":">=value"},{"field":[value1,value2]}]
+GET http://localhost/api/v1/Customers?$or=[{"field":"value"},{"$and",[{"field":"~value"},{"field":"!=value"}]}]
 ```
 
 ### Ordering & Sorting

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -61,7 +61,7 @@ var restify = function (app, model, opts) {
         options = getDefaults(),
         queryOptions = {
             protected: ['skip', 'limit', 'sort', 'populate', 'select', 'lean',
-                        '$and', '$or'],//H+ exposes query OR and AND methods
+                '$and', '$or', 'query'],//H+ exposes OR, AND and WHERE methods
             current: {}
         };
 
@@ -165,13 +165,17 @@ var restify = function (app, model, opts) {
             }
         }
 
-        //H+ exposes Query AND, OR methods
-        //TODO - add support for more logical operators supported by Mongoose
+        //H+ exposes Query AND, OR and WHERE methods
+        if (queryOptions.current.query) {
+            query.where(JSON.parse(queryOptions.current.query,
+                jsonQueryParser));
+        }
+        //TODO - as introduction of QUERY param obsoletes need of $and, $or
         if (queryOptions.current.$and) {
-            query.and(JSON.parse(queryOptions.current.$and, JSONReviewer));
+            query.and(JSON.parse(queryOptions.current.$and, jsonQueryParser));
         }
         if (queryOptions.current.$or) {
-            query.or(JSON.parse(queryOptions.current.$or, JSONReviewer));
+            query.or(JSON.parse(queryOptions.current.$or, jsonQueryParser));
         }
         //H+ exposes Query AND, OR methods
 
@@ -220,7 +224,7 @@ var restify = function (app, model, opts) {
 
     //H+ - JSON query param parser
     //TODO - improve to serve recursive logical operators
-    function JSONReviewer(key, value) {
+    function jsonQueryParser(key, value) {
         if (_.isString(value)) {
             if ('~' === value[0]) { //parse RegExp
                 return new RegExp(value.substring(1), 'i');

--- a/test/test.js
+++ b/test/test.js
@@ -383,6 +383,31 @@ function Restify() {
                     });
                 });
 
+                it('200 GET Products?query', function (done) {
+                        var query = { $or: [
+                            {name: '~Another'},
+                            {$and: [
+                                {name: '~Product'},
+                                {price: '<=10'}
+                            ]}
+                        ],
+                            price: 20
+                        };
+                        request.get({
+                            url: util.format('%s/api/v1/Products?query=%s',
+                                testUrl,
+                                encodeURIComponent(JSON.stringify(query))),
+                            json: true
+                        }, function (err, res, body) {
+                            assert.equal(res.statusCode, 200,
+                                'Wrong status code');
+                            assert.equal(body.length, 2,
+                                'Wrong count of customers returned');
+                            done();
+                        });
+                    }
+                );
+
                 it('200 GET Products?$and[?]', function (done) {
                     request.get({
                         url: util.format('%s/api/v1/Products?$and=%s',
@@ -393,7 +418,6 @@ function Restify() {
                         assert.equal(res.statusCode, 200, 'Wrong status code');
                         assert.equal(body.length, 2,
                             'Wrong count of customers returned');
-                        console.log(JSON.stringify(body));
                         done();
                     });
                 });
@@ -410,7 +434,6 @@ function Restify() {
                         assert.equal(res.statusCode, 200, 'Wrong status code');
                         assert.equal(body.length, 4,
                             'Wrong count of customers returned');
-                        console.log(JSON.stringify(body));
                         done();
                     });
                 });


### PR DESCRIPTION
Added QUERY parameter as suggested by @jperkelens 

```
var query = { $or: [
                {name: '~Another'},
                {$and: [
                    {name: '~Product'},
                    {price: '<=10'}
                ]}
            ],
                price: 20
            };
request({
    url: 'api/v1/Model',
    qs: { query: encodeURIComponent(JSON.stringify(query) }
})
GET http://localhost/api/v1/Customers?query={"field":">=value", "field":[value1,value2]
                                                 "$and":[{"field":"~value"},{"field":"!=value"}]}
```

Also I think we can deprecate $and, $or. As we can do the same with new query param 
