### PR TITLE
Add inline field access declaration

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -83,6 +83,19 @@ var restify = function(app, model, opts) {
     options.protected = options.protected ?
         options.protected.split(',') : [];
 
+    model.schema.eachPath(function(name, path) {
+        if (path.options.access) {
+            switch (path.options.access.toLowerCase()) {
+                case 'private':
+                    options.private.push(name);
+                    break;
+                case 'protected':
+                    options.protected.push(name);
+                    break;
+            }
+        }
+    });
+
     if (options.exclude) {
         options.private = options.exclude.split(',');
         console.error('Exclude is deprecated. Use private instead');

--- a/test/setup.js
+++ b/test/setup.js
@@ -27,7 +27,15 @@ var CustomerSchema = function () {
         purchases: [{
             item: { type: Schema.Types.ObjectId, ref: 'Product' },
             number: Number
-        }]
+        }],
+        creditCard: {
+            type: String,
+            access: 'protected'
+        },
+        ssn: {
+            type: String,
+            access: 'private'
+        }
     });
 };
 util.inherits(CustomerSchema, Schema);

--- a/test/test.js
+++ b/test/test.js
@@ -1147,7 +1147,9 @@ function RestifyCustomOutputFunction() {
                             json: {
                                 name: 'Test',
                                 comment: 'Comment',
-                                address: '123 Drury Lane'
+                                address: '123 Drury Lane',
+                                creditCard: '123412345612345',
+                                ssn: '123-45-6789'
                             },
                         }, function(err, res, body) {
                             savedCustomer = body;
@@ -1219,7 +1221,7 @@ function RestifyCustomOutputFunction() {
                     });
                 });
 
-                describe('proteced access', function() {
+                describe('protected access', function() {
                     before(function() {
                         access = 'protected';
                     });
@@ -1235,6 +1237,21 @@ function RestifyCustomOutputFunction() {
                             assert.ok(body.address === undefined,
                                 'address is not undefined');
                             assert.equal(body.comment, 'Comment');
+                            done();
+                        });
+                    });
+
+                    it('excludes private fields defined in the schema', function(done) {
+                        request.get({
+                            url: util.format('%s/api/v1/Customers/%s', testUrl,
+                                savedCustomer._id),
+                            json: true
+                        }, function(err, res, body) {
+                            assert.equal(body.name, 'Test');
+                            assert.ok(body.ssn === undefined,
+                                'ssn not undefined');
+                            assert.equal(body.comment, 'Comment');
+                            assert.equal(body.creditCard, '123412345612345');
                             done();
                         });
                     });


### PR DESCRIPTION
I think it's more convenient if you can declare the access to the field within the Mongoose schema itself, so I added this in. I don't see any conflicts that this would create.
