### PR TITLE
GET shallow model

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ POST http://localhost/api/v1/Customers
 DELETE http://localhost/api/v1/Customers
 
 GET http://localhost/api/v1/Customers/:id
+GET http://localhost/api/v1/Customers/:id/shallow
 PUT http://localhost/api/v1/Customers/:id
 POST http://localhost/api/v1/Customers/:id
 DELETE http://localhost/api/v1/Customers/:id

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -210,6 +210,7 @@ var restify = function(app, model, opts) {
     var uri_items = uri_item.replace('/:id', '');
 
     var uri_count = uri_items + '/count';
+    var uri_shallow = uri_item + '/shallow';
 
     function buildQuery(query, req) {
         var options = req.query,
@@ -598,6 +599,40 @@ var restify = function(app, model, opts) {
                     next();
                 }
             });
+        });
+    }, postProcess);
+    
+    app.get(uri_shallow, options.middleware, function(req, res, next) {
+        var byId = {};
+        byId[options.idProperty || '_id'] = req.params.id;
+        contextFilter(model, req, function(filteredContext) {
+            buildQuery(filteredContext.findOne().and(byId), req).lean(lean)
+                .findOne(function(err, item) {
+
+                    if (err || !item) {
+                        onError(res,next,createError(404, err));
+                    } else {
+                        var populate = queryOptions.current.populate,
+                            opts = {
+                                populate: populate,
+                                access: req.access
+                            };
+
+                        try {
+                            item = filter.filterObject(item, opts);
+                            for(var prop in item) {
+                                item[prop] = typeof item[prop] === 'object' && prop !== '_id' ?
+                                    true : item[prop];
+                            }
+
+                            outputFn(res, item);
+                            next();
+                        } catch(e) {
+                            e.status = 400;
+                            onError(res, next, e);
+                        }
+                    }
+                });
         });
     }, postProcess);
 

--- a/test/test.js
+++ b/test/test.js
@@ -129,16 +129,17 @@ module.exports = function(createFn) {
                 
                 it('200 GET Products/:id/shallow', function(done) {
                     request.get({
-                        url: util.format('%s/api/v1/Customers/%s/shallow', 
+                        url: util.format('%s/api/v1/Products/%s/shallow', 
                                          testUrl, savedProduct._id),
                         json: true
                     }, function(err, res, body) {
                         assert.equal(res.statusCode, 200, 'Wrong status code');
+                        var obj = {};
                         for(var prop in savedProduct) {
-                            savedProduct[prop] = typeof savedProduct[prop] === 'object' ? 
+                            obj[prop] = typeof savedProduct[prop] === 'object' && prop !== '_id' ? 
                                 true : savedProduct[prop];
                         }
-                        assert.deepEqual(body, savedProduct);
+                        assert.deepEqual(body, obj);
                         done();
                     });
                 });

--- a/test/test.js
+++ b/test/test.js
@@ -126,6 +126,22 @@ module.exports = function(createFn) {
                         done();
                     });
                 });
+                
+                it('200 GET Products/:id/shallow', function(done) {
+                    request.get({
+                        url: util.format('%s/api/v1/Customers/%s/shallow', 
+                                         testUrl, savedProduct._id),
+                        json: true
+                    }, function(err, res, body) {
+                        assert.equal(res.statusCode, 200, 'Wrong status code');
+                        for(var prop in savedProduct) {
+                            savedProduct[prop] = typeof savedProduct[prop] === 'object' ? 
+                                true : savedProduct[prop];
+                        }
+                        assert.deepEqual(body, savedProduct);
+                        done();
+                    });
+                });
 
                 it('200 GET Customers should return no objects', function(done) {
                     request.get({


### PR DESCRIPTION
Sometimes it's beneficial to only pull down the primitive values in the response. Objects and arrays will be replaced with `true` to acknowledge their existence.