### PR TITLE
Updated readme to use Express4 Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ var app = express();
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(methodOverride());
-restify.serve(app, CustomerModel);
-restify.serve(app, InvoiceModel);
+
+var router = express.Router();
+restify.serve(router, CustomerModel);
+restify.serve(router, InvoiceModel);
+app.use(router);
 
 app.listen(3000, function() {
-	console.log("Express server listening on port 3000");
+    console.log("Express server listening on port 3000");
 });
 ```
 


### PR DESCRIPTION
When using Express4, it is good practice not to pass the whole app, but instead simply pass the router.