### PR TITLE
usingExpress permissions error handling optimization

### DIFF
--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -7,7 +7,10 @@ exports.allow = function (usingExpress, prereq) {
         var handler = function (passed) {
             if (!passed) {
 				if(usingExpress) {
-                    return res.status(403).send(http.STATUS_CODES[403]);
+                    			var err = new Error();
+                    			err.status = 403;
+                    			next(err);
+                    			return;
 				} else {
 	                return res.send(403, {msg: http.STATUS_CODES[403]});
 				}


### PR DESCRIPTION
Since most express apps use their own error handler the response should not be defined here, but rather in the user defined error handler.

I have not looked at the tests so I'm not sure whether or not this will break them.