### PR TITLE
Improve onError and support custom handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ serve(app, model, [options])
   * **plural** - If `true`, does not pluralize the database model name. Default is `false`
   * **lowercase** - If `true`, turn model name to lower case before generating the routes.
   * **name** - If specified, this is used as the name of the endpoint
-  * **onError** - A function with the signature `function(req, res, next, err)` that is used to output an error. `err` is the error object that is returned by mongoose. Works best with `fullErrors = true`
+  * **onError** - A function with the signature `function(err, req, res, next)` that is used to output an error. `err` is the error object that is returned by mongoose. Works best with `fullErrors = true`
   * **outputFn** - A function with the signature `function(res, result)` that is used to output the result. `res` is a restify or express result object, `result` is the result that is returned from the mongo db.
   * **private** - String of comma separated field names which are not to be returned by queries that do not have private access.
   * **protected** - String of comma separated field names which are not to be returned by queries that have public access.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ serve(app, model, [options])
   * **plural** - If `true`, does not pluralize the database model name. Default is `false`
   * **lowercase** - If `true`, turn model name to lower case before generating the routes.
   * **name** - If specified, this is used as the name of the endpoint
+  * **onError** - A function with the signature `function(req, res, next, err)` that is used to output an error. `err` is the error object that is returned by mongoose. Works best with `fullErrors = true`
   * **outputFn** - A function with the signature `function(res, result)` that is used to output the result. `res` is a restify or express result object, `result` is the result that is returned from the mongo db.
   * **private** - String of comma separated field names which are not to be returned by queries that do not have private access.
   * **protected** - String of comma separated field names which are not to be returned by queries that have public access.

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -148,7 +148,7 @@ var restify = function(app, model, opts) {
         }
 
         if(err) {
-            onError(res,next,err);
+            onError(err, req, res, next);
         } else {
             next();
         }
@@ -168,7 +168,7 @@ var restify = function(app, model, opts) {
         return err;
     }
 
-    function onError(res, next, err) {
+    var onError = options.onError ? options.onError : function(err, req, res, next) {
         var errorString;
         if (options.fullErrors) {
             res.setHeader('Content-Type', 'application/json');
@@ -182,7 +182,7 @@ var restify = function(app, model, opts) {
         } else {
             res.send(err.status, errorString);
         }
-    }
+    };
 
     options.middleware.push(cleanQuery);
 
@@ -359,7 +359,7 @@ var restify = function(app, model, opts) {
     function ensureContentType(req, res, next) {
         var ct = req.headers['content-type'];
         if (-1 === ct.indexOf('application/json')) {
-            onError(res,next,createError(400));
+            onError(createError(400), req, res, next);
         } else {
             next();
         }
@@ -395,7 +395,7 @@ var restify = function(app, model, opts) {
 
     function createObject(req, res, next) {
         if (!req.body) {
-            onError(res,next,createError(400));
+            onError(createError(400), req, res, next);
             return;
         }
 
@@ -421,7 +421,7 @@ var restify = function(app, model, opts) {
         model.create(req.body, function(err, item) {
             if (err) {
                 err.status = 400;
-                onError(res, next, err);
+                onError(err, req, res, next);
             } else {
                 var result = null;
 
@@ -435,7 +435,7 @@ var restify = function(app, model, opts) {
 
                 postCreate(res, result, function(err) {
                     if (err) {
-                        onError(res,next,createError(400, err));
+                        onError(createError(400, err), req, res, next);
                     }
                     else {
                         // 201 - Created
@@ -451,7 +451,7 @@ var restify = function(app, model, opts) {
         var byId = {};
         byId[options.idProperty || '_id'] = req.params.id;
         if (!req.body) {
-            onError(res,next,createError(400));
+            onError(createError(400), req, res, next);
             return;
         }
 
@@ -494,7 +494,7 @@ var restify = function(app, model, opts) {
                 filteredContext.findOneAndUpdate(byId, req.body, {},
                     function(err, item) {
                         if (err || !item) {
-                            onError(res,next,createError(404, err));
+                            onError(createError(404, err), req, res, next);
                         } else {
                             item = filter.filterObject(item, filterOpts);
                             outputFn(res, item);
@@ -506,7 +506,7 @@ var restify = function(app, model, opts) {
             contextFilter(model, req, function(filteredContext) {
                 filteredContext.findOne(byId, function(err, doc) {
                     if (err || !doc) {
-                        onError(res,next,createError(404, err));
+                        onError(createError(404, err), req, res, next);
                     } else {
                         for (var key in req.body) {
                             doc[key] = req.body[key];
@@ -514,7 +514,7 @@ var restify = function(app, model, opts) {
                         doc.save(function(err, item) {
                             if (err) {
                                 err.status = 400;
-                                onError(res,next,err);
+                                onError(err, req, res, next);
                             } else {
                                 item = filter.filterObject(item, filterOpts);
                                 outputFn(res, item);
@@ -574,7 +574,7 @@ var restify = function(app, model, opts) {
             buildQuery(filteredContext.find(), req).lean(lean)
                 .exec(function(err, items) {
                     if (err) {
-                        onError(res,next,createError(400, err));
+                        onError(createError(400, err), req, res, next);
                     } else {
                         var populate = queryOptions.current.populate,
                             opts = {
@@ -591,7 +591,7 @@ var restify = function(app, model, opts) {
                             next();
                         } catch(e) {
                             e.status = 400;
-                            onError(res, next, e);
+                            onError(e, req, res, next);
                         }
                     }
                 });
@@ -602,7 +602,7 @@ var restify = function(app, model, opts) {
         contextFilter(model, req, function(filteredContext) {
             buildQuery(filteredContext.count(), req).exec(function(err, count) {
                 if (err) {
-                    onError(res,next,createError(400, err));
+                    onError(createError(400, err), req, res, next);
                 } else {
                     outputFn(res, { count: count });
                     next();
@@ -619,7 +619,7 @@ var restify = function(app, model, opts) {
                 .findOne(function(err, item) {
 
                     if (err || !item) {
-                        onError(res,next,createError(404, err));
+                        onError(createError(404, err), req, res, next);
                     } else {
                         var populate = queryOptions.current.populate,
                             opts = {
@@ -638,7 +638,7 @@ var restify = function(app, model, opts) {
                             next();
                         } catch(e) {
                             e.status = 400;
-                            onError(res, next, e);
+                            onError(e, req, res, next);
                         }
                     }
                 });
@@ -658,7 +658,7 @@ var restify = function(app, model, opts) {
                 var results, error;
                 buildQuery(filteredContext.find(), req).remove(function(err, items) {
                     if (err) {
-                        onError(res,next,createError(400, err));
+                        onError(createError(400, err), req, res, next);
                     } else {
                         // 204 - No Content
                         if(usingExpress) {
@@ -681,7 +681,7 @@ var restify = function(app, model, opts) {
                 .findOne(function(err, item) {
 
                     if (err || !item) {
-                        onError(res,next,createError(404, err));
+                        onError(createError(404, err), req, res, next);
                     } else {
                         var populate = queryOptions.current.populate,
                             opts = {
@@ -698,7 +698,7 @@ var restify = function(app, model, opts) {
                             next();
                         } catch(e) {
                             e.status = 400;
-                            onError(res, next, e);
+                            onError(e, req, res, next);
                         }
                     }
                 });
@@ -722,11 +722,11 @@ var restify = function(app, model, opts) {
                 filteredContext.find().and(byId).findOneAndRemove(
                     function(err, result) {
                     if (err || !result) {
-                        onError(res,next,createError(404, err));
+                        onError(createError(404, err), req, res, next);
                     } else {
                         postDelete(res, result, function(err) {
                             if (err) {
-                                onError(res,next,createError(400, err));
+                                onError(createError(400, err), req, res, next);
                             }
                             else {
                                 // 204 - No Content
@@ -745,12 +745,12 @@ var restify = function(app, model, opts) {
             contextFilter(model, req, function(filteredContext) {
                 filteredContext.findOne(byId, function(err, doc) {
                     if (err || !doc) {
-                        onError(res,next,createError(404, err));
+                        onError(createError(404, err), req, res, next);
                     } else {
                         doc.remove(function(err, result) {
                             postDelete(res, doc, function(err) {
                                 if (err) {
-                                    onError(res,next,createError(400, err));
+                                    onError(createError(400, err), req, res, next);
                                 }
                                 else {
                                     // 204 - No Content


### PR DESCRIPTION
This does two things:

1. Change the `onError` function signature from `res, next, err` to the conventional `err, req, res, next`
2. Support passing a custom handler as an option

```javascript
restify.defaults({
  onError: function(err, req, res, next) {
    res.status(err.status).json({
      custom: 'data',
      message: err.message
    });
  }
});
```