### PR TITLE
Remove permissions.js error handler, use existing handler instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp
 node_modules
 npm-debug.log
 /.idea
+nbproject

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -530,7 +530,7 @@ var restify = function(app, model, opts) {
     var write_middleware = options.middleware.slice(0, -1);
 
     if (options.prereq) {
-        var allowMW = permissions.allow(usingExpress, options.prereq);
+        var allowMW = permissions.allow(options.prereq, onError);
         write_middleware = [allowMW].concat(write_middleware);
     }
 

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -2,19 +2,16 @@
 
 var http = require('http');
 
-exports.allow = function (usingExpress, prereq) {
+exports.allow = function (prereq, onError) {
     return function (req, res, next) {
         var handler = function (passed) {
             if (!passed) {
-				if(usingExpress) {
-                    			var err = new Error();
-                    			err.status = 403;
-                    			next(err);
-                    			return;
-				} else {
-	                return res.send(403, {msg: http.STATUS_CODES[403]});
-				}
+                var err = new Error();
+                err.status = 403;
+                err.message = http.STATUS_CODES[403];
+                return onError(err, req, res, next);
             }
+            
             next();
         };
 

--- a/test/permissions.js
+++ b/test/permissions.js
@@ -33,19 +33,21 @@ describe('permissions', function () {
                 return true;
             };
 
-            middleware.allow(false, prereq)({}, res, function () {
+            middleware.allow(prereq)({}, res, function () {
                 assert(true);
                 done();
             });
         });
 
-        it('fails', function () {
+        it('fails', function (done) {
             var prereq = function () {
                 return false;
             };
 
-            middleware.allow(false, prereq)({}, res);
-            this.mock.verify();
+            middleware.allow(prereq, function () {
+                assert(true);
+                done();
+            })({}, res);
         });
     });
 
@@ -53,17 +55,19 @@ describe('permissions', function () {
         it('passes', function (done) {
             var prereq = function (req, cb) { cb(true); };
 
-            middleware.allow(false, prereq)({}, res, function () {
+            middleware.allow(prereq)({}, res, function () {
                 assert(true);
                 done();
             });
         });
 
-        it('fails', function () {
+        it('fails', function (done) {
             var prereq = function (req, cb) { cb(false); };
 
-            middleware.allow(false, prereq)({}, res);
-            this.mock.verify();
+            middleware.allow(prereq, function () {
+                assert(true);
+                done();
+            })({}, res);
         });
     });
 


### PR DESCRIPTION
*This is an improvement on the thinking behind #92.*

The idea being that the permissions script shouldn't do it's own error handling, but rather pass it over to the existing `onError` function, default or custom. It also means permissions no longer need to know about `usingExpress`.

I changed the tests accordingly, but you might want to review them first to make sure they're really working as intended.