### PR TITLE
Make 204 responses pass through the outputFn

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -58,11 +58,17 @@ function getDefaults() {
 }
 
 function outputExpress(res, result, statusCode) {
-    res.status(statusCode || 200).json(result);
+    if (result !== null)
+        res.status(statusCode || 200).json(result);
+    else
+        res.status(statusCode || 200).end();
 }
 
 function outputRestify(res, result, statusCode) {
-    res.send(statusCode || 200, result);
+    if (result !== null)
+        res.send(statusCode || 200, result);
+    else
+        res.send(statusCode || 200);
 }
 
 var restify = function(app, model, opts) {
@@ -658,11 +664,7 @@ var restify = function(app, model, opts) {
                         onError(createError(400, err), req, res, next);
                     } else {
                         // 204 - No Content
-                        if(usingExpress) {
-                            res.status(204).end();
-                        } else {
-                            res.send(204);
-                        }
+                        outputFn(res, null, 204);
                         next();
                     }
                 });
@@ -727,11 +729,7 @@ var restify = function(app, model, opts) {
                             }
                             else {
                                 // 204 - No Content
-                                if(usingExpress) {
-                                    res.status(204).end();
-                                } else {
-                                    res.send(204);
-                                }
+                                outputFn(res, null, 204);
                                 next();
                             }
                         });
@@ -751,11 +749,7 @@ var restify = function(app, model, opts) {
                                 }
                                 else {
                                     // 204 - No Content
-                                    if(usingExpress) {
-                                        res.status(204).end();
-                                    } else {
-                                        res.send(204);
-                                    }
+                                    outputFn(res, null, 204);
                                     next();
                                 }
                             });

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -58,17 +58,19 @@ function getDefaults() {
 }
 
 function outputExpress(res, result, statusCode) {
-    if (result !== null)
+    if (result !== null) {
         res.status(statusCode || 200).json(result);
-    else
+    } else {
         res.status(statusCode || 200).end();
+    }
 }
 
 function outputRestify(res, result, statusCode) {
-    if (result !== null)
+    if (result !== null) {
         res.send(statusCode || 200, result);
-    else
+    } else {
         res.send(statusCode || 200);
+    }
 }
 
 var restify = function(app, model, opts) {


### PR DESCRIPTION
At the moment, all the output responses flow through either the `onError` or `outputFn` callback, but in case of 204 (No content) responses (such as the response to a DELETE request), those were written directly to the Express (or Restify) response.

This patch makes the `outputFn` able to handle 204 responses. The default behaviour, though, has not changed.