### PR TITLE
improve select and populate query variables

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -293,36 +293,16 @@ var restify = function(app, model, opts) {
                 query.sort(queryOptions.current.sort);
             }
         }
-        var selectObj = {root: {}};
         if (queryOptions.current.select) {
-
-            if (queryOptions.current.select) {
-                arr = queryOptions.current.select.split(',');
-                for (i = 0; i < arr.length; ++i) {
-                    if (arr[i].match(/\./)) {
-                        var subSelect = arr[i].split('.');
-                        if (!selectObj[subSelect[0]]) {
-                            selectObj[subSelect[0]] = {};
-                            //selectObj.root[subSelect[0]] = 1;
-                        }
-                        selectObj[subSelect[0]][subSelect[1]] = 1;
-                    } else {
-                        selectObj.root[arr[i]] = 1;
-                    }
-                }
+            var selectObj = {};
+            arr = queryOptions.current.select.split(',');
+            for (i = 0; i < arr.length; ++i) {
+                selectObj[arr[i]] = 1;
             }
-            query = query.select(selectObj.root);
+            query = query.select(selectObj);
         }
         if (queryOptions.current.populate) {
-            arr = queryOptions.current.populate.split(',');
-            for (i = 0; i < arr.length; ++i) {
-                if (!_.isUndefined(selectObj[arr[i]]) &&
-                    !_.isEmpty(selectObj.root)) {
-                    selectObj.root[arr[i]] = 1;
-                }
-                query = query.populate(arr[i], selectObj[arr[i]]);
-            }
-            query.select(selectObj.root);
+            query = query.populate(queryOptions.current.populate.replace( /,/g, " " ));
         }
         if (queryOptions.current.projection) {
             query.select(JSON.parse(queryOptions.current.projection, jsonQueryParser));


### PR DESCRIPTION
At the moment, using `?select=field.subfield` does not work, nor does `?populate=field.subfield`.
This commit aims at providing this feature. However, I simplified the code quite a lot, so I hope I am not missing anything important here.
The build is failing at the moment (jshint + test units), but I would like to know your feedback, since it seems like this feature has already been implemented (according to the test unit), so this pull request might be useless.