### PR TITLE
refactor(clean): clone req.query to leave it intact

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -134,11 +134,12 @@ var restify = function(app, model, opts) {
 
     function cleanQuery(req, res, next) {
         queryOptions.current = {};
+        queryOptions.clean = _.clone(req.query);
         var err = null;
-        for (var key in req.query) {
+        for (var key in queryOptions.clean) {
             if (queryOptions.protected.indexOf(key) !== -1) {
-                queryOptions.current[key] = req.query[key];
-                delete req.query[key];
+                queryOptions.current[key] = queryOptions.clean[key];
+                delete queryOptions.clean[key];
             } else if (!model.schema.paths.hasOwnProperty(key)) {
                 var keys = key.match('.') &&
                     !model.schema.paths.hasOwnProperty(key) ?
@@ -227,7 +228,7 @@ var restify = function(app, model, opts) {
     var uri_shallow = uri_item + '/shallow';
 
     function buildQuery(query, req) {
-        var options = req.query,
+        var options = queryOptions.clean,
             excludedarr = filter.getExcluded(req.access);
 
         var arr, i, re;


### PR DESCRIPTION
By cloning req.query, it can be accessed as expected after a request as
gone through the cleanQuery middleware.