### PR TITLE
Add support for excluding fields in selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ GET http://localhost/api/v1/Customers?name=<value
 GET http://localhost/api/v1/Customers?name=<=value
 GET http://localhost/api/v1/Customers?name=!=value
 GET http://localhost/api/v1/Customers?select=name
+GET http://localhost/api/v1/Customers?select=-name
 ```
 ## Mongoose Query
 ```

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -298,15 +298,20 @@ var restify = function(app, model, opts) {
         if (queryOptions.current.select) {
             arr = queryOptions.current.select.split(',');
             for (i = 0; i < arr.length; ++i) {
-                if (arr[i].match(/\./)) {
-                    var subSelect = arr[i].split('.');
+                var selectItem = arr[i];
+                var selectionModifier = 1;
+                if (selectItem.match(/^\-/)) { // exclusion
+                    selectItem = selectItem.substring(1);
+                    selectionModifier = 0;
+                }
+                if (selectItem.match(/\./)) {
+                    var subSelect = selectItem.split('.');
                     if (!selectObj[subSelect[0]]) {
                         selectObj[subSelect[0]] = {};
-                        //selectObj.root[subSelect[0]] = 1;
                     }
-                    selectObj[subSelect[0]][subSelect[1]] = 1;
+                    selectObj[subSelect[0]][subSelect[1]] = selectionModifier;
                 } else {
-                    selectObj.root[arr[i]] = 1;
+                    selectObj.root[selectItem] = selectionModifier;
                 }
             }
             query = query.select(selectObj.root);

--- a/test/test.js
+++ b/test/test.js
@@ -514,6 +514,22 @@ module.exports = function(createFn) {
                             done();
                         });
                     });
+                    it('200 GET Customers/:id?select=-name should not fetch name ' +
+                        '(but e.g. comment should be available)', function(done) {
+                        request.get({
+                            url: util.format('%s/api/v1/Customers/%s?select=-name',
+                                testUrl,
+                                savedCustomer._id),
+                            json: true
+                        }, function(err, res, body) {
+                            assert.equal(res.statusCode, 200, 'Wrong status code');
+                            assert.equal(undefined, body.name,
+                                'Name field should not be included');
+                            assert.equal('Comment', body.comment,
+                                'Comment field should be included');
+                            done();
+                        });
+                    });
 
                     it('200 GET Invoices/:id?populate=customer&select=' +
                         'customer.name,amount should not fetch ' +


### PR DESCRIPTION
When using "select('-myField') in mongoose, it excludes the
field named 'myField.
In restify, it used to include include a field named '-myField'
instead of excluding the field named 'myField'.