### PR TITLE
use findById where possible

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -227,6 +227,16 @@ var restify = function(app, model, opts) {
     var uri_count = uri_items + '/count';
     var uri_shallow = uri_item + '/shallow';
 
+    function findById(filteredContext, id) {
+        if (options.idProperty || !filteredContext.findById) {
+            var byId = {};
+            byId[options.idProperty || '_id'] = id;
+            return filteredContext.findOne().and(byId);
+        } else {
+            return filteredContext.findById(id);
+        }
+    }
+
     function buildQuery(query, req) {
         var options = queryOptions.clean,
             excludedarr = filter.getExcluded(req.access);
@@ -457,8 +467,6 @@ var restify = function(app, model, opts) {
     }
 
     function modifyObject(req, res, next) {
-        var byId = {};
-        byId[options.idProperty || '_id'] = req.params.id;
         if (!req.body) {
             onError(createError(400), req, res, next);
             return;
@@ -500,7 +508,7 @@ var restify = function(app, model, opts) {
 
         if (options.findOneAndUpdate) {
             contextFilter(model, req, function(filteredContext) {
-                filteredContext.findOneAndUpdate(byId, req.body, {},
+                findById(filteredContext, req.params.id).findOneAndUpdate({}, req.body, {},
                     function(err, item) {
                         if (err || !item) {
                             onError(createError(404, err), req, res, next);
@@ -513,7 +521,7 @@ var restify = function(app, model, opts) {
             });
         } else {
             contextFilter(model, req, function(filteredContext) {
-                filteredContext.findOne(byId, function(err, doc) {
+                findById(filteredContext, req.params.id).exec(function(err, doc) {
                     if (err || !doc) {
                         onError(createError(404, err), req, res, next);
                     } else {
@@ -618,12 +626,9 @@ var restify = function(app, model, opts) {
     }, postProcess);
     
     app.get(uri_shallow, options.middleware, function(req, res, next) {
-        var byId = {};
-        byId[options.idProperty || '_id'] = req.params.id;
         contextFilter(model, req, function(filteredContext) {
-            buildQuery(filteredContext.findOne().and(byId), req).lean(lean)
-                .findOne(function(err, item) {
-
+            buildQuery(findById(filteredContext, req.params.id), req).lean(lean)
+                .exec(function(err, item) {
                     if (err || !item) {
                         onError(createError(404, err), req, res, next);
                     } else {
@@ -675,12 +680,9 @@ var restify = function(app, model, opts) {
     }
 
     app.get(uri_item, options.middleware, function(req, res, next) {
-        var byId = {};
-        byId[options.idProperty || '_id'] = req.params.id;
         contextFilter(model, req, function(filteredContext) {
-            buildQuery(filteredContext.findOne().and(byId), req).lean(lean)
-                .findOne(function(err, item) {
-
+            buildQuery(findById(filteredContext, req.params.id), req).lean(lean)
+                .exec(function(err, item) {
                     if (err || !item) {
                         onError(createError(404, err), req, res, next);
                     } else {
@@ -719,8 +721,7 @@ var restify = function(app, model, opts) {
 
         if (options.findOneAndRemove) {
             contextFilter(model, req, function(filteredContext) {
-                filteredContext.find().and(byId).findOneAndRemove(
-                    function(err, result) {
+                findById(filteredContext, req.params.id).findOneAndRemove(function(err, result) {
                     if (err || !result) {
                         onError(createError(404, err), req, res, next);
                     } else {
@@ -739,7 +740,7 @@ var restify = function(app, model, opts) {
             });
         } else {
             contextFilter(model, req, function(filteredContext) {
-                filteredContext.findOne(byId, function(err, doc) {
+                findById(filteredContext, req.params.id).exec(function(err, doc) {
                     if (err || !doc) {
                         onError(createError(404, err), req, res, next);
                     } else {


### PR DESCRIPTION
- refactor all calls to findOne & findOneAndX to use findById
  if no alternative idProperty is provided
- extract duplicate creation of byId condition to a separate
  method