### PR TITLE
refactor(options): remove strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,5 @@ Changelog
 * removed `strict` option, allows DELETE without id and POST with id, disallows PUT without id
 * async `prereq` and `access` now use the standard `(err, data)` callback signature
 * `access` will throw an exception when an unsupported value is passed
-* changed `outputFn`'s signature to:
-  ```javascript
-  outputFn(req, res, next, {
-    result: result,
-    statusCode: statusCode
-  })
-  ```
+* changed `outputFn`'s signature to: `(req, res, next, { result: result, statusCode: statusCode })`
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,4 @@ Changelog
 * removed `strict` option, allows DELETE without id and POST with id, disallows PUT without id
 * async `prereq` and `access` now use the standard `(err, data)` callback signature
 * `access` will throw an exception when an unsupported value is passed
-* changed `outputFn`'s signature to: `(req, res, next, { result: result, statusCode: statusCode })`
-
+* changed `outputFn`'s signature to: `(req, res, { result: result, statusCode: statusCode })`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,14 @@ Changelog
 > **This release is no longer compatible with mongoose 3**
 
 * updated mongoose to version 4
-* removed fullErrors, implement a custom onError handler instead
+* removed `fullErrors`, implement a custom `onError` handler instead
+* removed `strict` option, allows DELETE without id and POST with id, disallows PUT without id
+* async `prereq` and `access` now use the standard `(err, data)` callback signature
+* `access` will throw an exception when an unsupported value is passed
+* changed `outputFn`'s signature to:
+  ```javascript
+  outputFn(req, res, next, {
+    result: result,
+    statusCode: statusCode
+  })
+  ```

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -50,19 +50,19 @@ function getDefaults() {
     return options;
 }
 
-function outputExpress(res, result, statusCode) {
-    if (result !== null) {
-        res.status(statusCode || 200).json(result);
+function outputExpress(req, res, data) {
+    if (data.result !== null) {
+        res.status(data.statusCode || 200).json(data.result);
     } else {
-        res.status(statusCode || 200).end();
+        res.status(data.statusCode || 200).end();
     }
 }
 
-function outputRestify(res, result, statusCode) {
-    if (result !== null) {
-        res.send(statusCode || 200, result);
+function outputRestify(req, res, data) {
+    if (data.result !== null) {
+        res.send(data.statusCode || 200, data.result);
     } else {
-        res.send(statusCode || 200);
+        res.send(data.statusCode || 200);
     }
 }
 
@@ -435,7 +435,10 @@ var restify = function(app, model, opts) {
                     }
                     else {
                         // 201 - Created
-                        outputFn(res, result, 201);
+                        outputFn(req, res, {
+                          result: result,
+                          statusCode: 201
+                        });
                         next();
                     }
                 });
@@ -499,7 +502,10 @@ var restify = function(app, model, opts) {
                         onError(err, req, res, next);
                     } else {
                         item = filter.filterObject(item, filterOpts);
-                        outputFn(res, item);
+                        outputFn(req, res, {
+                          result: item,
+                          statusCode: 200
+                        });
                         next();
                     }
                 });
@@ -524,7 +530,10 @@ var restify = function(app, model, opts) {
                                 onError(err, req, res, next);
                             } else {
                                 item = filter.filterObject(item, filterOpts);
-                                outputFn(res, item);
+                                outputFn(req, res, {
+                                  result: item,
+                                  statusCode: 200
+                                });
                                 next();
                             }
                         });
@@ -592,7 +601,10 @@ var restify = function(app, model, opts) {
 
                         try {
                             items = filter.filterObject(items, opts);
-                            outputFn(res, items);
+                            outputFn(req, res, {
+                              result: items,
+                              statusCode: 200
+                            });
                             next();
                         } catch(e) {
                             e.status = 400;
@@ -610,7 +622,10 @@ var restify = function(app, model, opts) {
                     err.status = 400;
                     onError(err, req, res, next);
                 } else {
-                    outputFn(res, { count: count });
+                    outputFn(req, res, {
+                      result: { count: count },
+                      statusCode: 200
+                    });
                     next();
                 }
             });
@@ -642,7 +657,10 @@ var restify = function(app, model, opts) {
                                     true : item[prop];
                             }
 
-                            outputFn(res, item);
+                            outputFn(req, res, {
+                              result: item,
+                              statusCode: 200
+                            });
                             next();
                         } catch(e) {
                             e.status = 400;
@@ -663,7 +681,9 @@ var restify = function(app, model, opts) {
                     onError(err, req, res, next);
                 } else {
                     // 204 - No Content
-                    outputFn(res, null, 204);
+                    outputFn(req, res, {
+                      statusCode: 204
+                    });
                     next();
                 }
             });
@@ -693,7 +713,10 @@ var restify = function(app, model, opts) {
 
                             // if null 404 - not found else 200
                             var statusCode = item ? 200 : 404;
-                            outputFn(res, item, statusCode);
+                            outputFn(req, res, {
+                              result: item,
+                              statusCode: statusCode
+                            });
                             next();
                         } catch(e) {
                             e.status = 400;
@@ -729,7 +752,9 @@ var restify = function(app, model, opts) {
                             }
                             else {
                                 // 204 - No Content
-                                outputFn(res, null, 204);
+                                outputFn(req, res, {
+                                  statusCode: 204
+                                });
                                 next();
                             }
                         });
@@ -755,7 +780,9 @@ var restify = function(app, model, opts) {
                                 }
                                 else {
                                     // 204 - No Content
-                                    outputFn(res, null, 204);
+                                    outputFn(req, res, {
+                                      statusCode: 204
+                                    });
                                     next();
                                 }
                             });

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -41,7 +41,6 @@ function getDefaults() {
         lean: true,
         plural: true,
         middleware: [],
-        strict: false,
         findOneAndUpdate: true,
         findOneAndRemove: true,
         contextFilter: null,
@@ -656,27 +655,20 @@ var restify = function(app, model, opts) {
 
     app.post(uri_items, write_middleware, createObject, postProcess);
 
-    if (!options.strict) {
-        app.put(uri_items, write_middleware, createObject, postProcess);
-    }
-
-    if (!options.strict) {
-        // TODO: reconsider this function
-        app.delete(uri_items, delete_middleware, function(req, res, next) {
-            contextFilter(model, req, function(filteredContext) {
-                buildQuery(filteredContext.find(), req).remove(function(err, items) {
-                    if (err) {
-                        err.status = 400;
-                        onError(err, req, res, next);
-                    } else {
-                        // 204 - No Content
-                        outputFn(res, null, 204);
-                        next();
-                    }
-                });
+    app.delete(uri_items, delete_middleware, function(req, res, next) {
+        contextFilter(model, req, function(filteredContext) {
+            buildQuery(filteredContext.find(), req).remove(function(err, items) {
+                if (err) {
+                    err.status = 400;
+                    onError(err, req, res, next);
+                } else {
+                    // 204 - No Content
+                    outputFn(res, null, 204);
+                    next();
+                }
             });
-        }, postProcess);
-    }
+        });
+    }, postProcess);
 
     app.get(uri_item, options.middleware, function(req, res, next) {
         contextFilter(model, req, function(filteredContext) {
@@ -712,11 +704,7 @@ var restify = function(app, model, opts) {
         });
     }, postProcess);
 
-    if (!options.strict) {
-        // TODO: POST (create) doesn't make sense here
-        app.post(uri_item, write_middleware, modifyObject, postProcess);
-    }
-
+    app.post(uri_item, write_middleware, modifyObject, postProcess);
     app.put(uri_item, write_middleware, modifyObject, postProcess);
 
     app.delete(uri_item, delete_middleware, function(req, res, next) {

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -553,7 +553,7 @@ var restify = function(app, model, opts) {
     var delete_middleware = write_middleware.slice(0);
 
     if (options.access) {
-        var accessMW = permissions.access(options.access);
+        var accessMW = permissions.access(options.access, onError);
         options.middleware.push(accessMW);
         write_middleware.push(accessMW);
     }

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -4,11 +4,14 @@ var http = require('http');
 
 exports.allow = function (prereq, onError) {
     return function (req, res, next) {
-        var handler = function (passed) {
+        var handler = function (err, passed) {
+            if (err) {
+                return onError(err, req, res, next);
+            }
+            
             if (!passed) {
-                var err = new Error();
+                err = new Error(http.STATUS_CODES[403]);
                 err.status = 403;
-                err.message = http.STATUS_CODES[403];
                 return onError(err, req, res, next);
             }
             
@@ -18,14 +21,22 @@ exports.allow = function (prereq, onError) {
         if (prereq.length > 1) {
             prereq(req, handler);
         } else {
-            handler(prereq(req));
+            handler(null, prereq(req));
         }
     };
 };
 
-exports.access = function (accessFn) {
+exports.access = function (accessFn, onError) {
     return function (req, res, next) {
-        var handler = function (access) {
+        var handler = function (err, access) {
+            if (err) {
+                return onError(err, req, res, next);
+            }
+            
+            if (['public', 'private', 'protected'].indexOf(access) < 0) {
+                throw new Error('Unsupported access, must be "public", "private" or "protected"');
+            }
+            
             req.access = access;
             next();
         };
@@ -33,7 +44,7 @@ exports.access = function (accessFn) {
         if (accessFn.length > 1) {
             accessFn(req, handler);
         } else {
-            handler(accessFn(req));
+            handler(null, accessFn(req));
         }
     };
 };

--- a/test/express.js
+++ b/test/express.js
@@ -17,9 +17,9 @@ function ExpressCustomOutputFunction() {
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({ extended: true }));
     app.use(methodOverride());
-    app.outputFn = function(res, result, statusCode) {
+    app.outputFn = function(req, res, data) {
         res.type('json');
-        res.status(statusCode || 200).send(JSON.stringify(result));
+        res.status(data.statusCode || 200).send(JSON.stringify(data.result));
     };
     return app;
 }

--- a/test/permissions.js
+++ b/test/permissions.js
@@ -53,7 +53,7 @@ describe('permissions', function () {
 
     describe('with prereq that yields', function (done) {
         it('passes', function (done) {
-            var prereq = function (req, cb) { cb(true); };
+            var prereq = function (req, cb) { cb(null, true); };
 
             middleware.allow(prereq)({}, res, function () {
                 assert(true);
@@ -62,7 +62,7 @@ describe('permissions', function () {
         });
 
         it('fails', function (done) {
-            var prereq = function (req, cb) { cb(false); };
+            var prereq = function (req, cb) { cb(null, false); };
 
             middleware.allow(prereq, function () {
                 assert(true);
@@ -83,19 +83,47 @@ describe('permissions', function () {
                 done();
             });
         });
+        
+        it('throws an exception with unsupported parameter', function () {
+            var req = {},
+                next = sinon.spy(),
+                accessFn = function () {
+                    return 'foo';
+                };
+            
+            assert.throws(function() {
+                middleware.access(accessFn)(req, {}, next);
+            }, 'Unsupported access, must be "public", "private" or "protected"');
+            
+            sinon.assert.notCalled(next);
+        });
     });
 
     describe('with access that yields', function () {
         it('adds access field to req', function (done) {
             var req = {},
                 accessFn = function (req, cb) {
-                    return cb('private');
+                    return cb(null, 'private');
                 };
 
             middleware.access(accessFn)(req, {}, function () {
                 assert.equal(req.access, 'private');
                 done();
             });
+        });
+        
+        it('throws an exception with unsupported parameter', function () {
+            var req = {},
+                next = sinon.spy(),
+                accessFn = function (req, cb) {
+                    return cb(null, 'foo');
+                };
+            
+            assert.throws(function() {
+                middleware.access(accessFn)(req, {}, next);
+            }, 'Unsupported access, must be "public", "private" or "protected"');
+            
+            sinon.assert.notCalled(next);
         });
     });
 });

--- a/test/restify.js
+++ b/test/restify.js
@@ -15,8 +15,8 @@ function RestifyCustomOutputFunction() {
     app.use(restify.queryParser());
     app.use(restify.bodyParser());
     app.isRestify = true;
-    app.outputFn = function(res, result, statusCode) {
-        res.send(statusCode || 200, result);
+    app.outputFn = function(req, res, data) {
+        res.send(data.statusCode || 200, data.result);
     };
     return app;
 }


### PR DESCRIPTION
Basically, what used to be strict mode is now always on.

- Allow DELETE without id
- Allow POST with id
- Disallow PUT without id

Ugh, that was intended to be two PR's. Oh well.

The second commit is about passing req into outputFn