### PR TITLE
fix: do not override status if already set

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -430,7 +430,7 @@ var restify = function(app, model, opts) {
 
                 postCreate(res, result, function(err) {
                     if (err) {
-                        err.status = 400;
+                        err.status = err.status || 400;
                         onError(err, req, res, next);
                     }
                     else {
@@ -747,7 +747,7 @@ var restify = function(app, model, opts) {
                     } else {
                         postDelete(res, result, function(err) {
                             if (err) {
-                                err.status = 400;
+                                err.status = err.status || 400;
                                 onError(err, req, res, next);
                             }
                             else {
@@ -775,7 +775,7 @@ var restify = function(app, model, opts) {
                         doc.remove(function(err, result) {
                             postDelete(res, doc, function(err) {
                                 if (err) {
-                                    err.status = 400;
+                                    err.status = err.status || 400;
                                     onError(err, req, res, next);
                                 }
                                 else {


### PR DESCRIPTION
A custom postCreate or postDelete may set it's own status code.

Currently when you do something like this:

```javascript
postCreate: function(res, result, done) {
    var err = new Error("Something went wrong!");
    err.status = 500;
    done(err);
}
```

Instead of sending 500, it gets overwritten with 400. This PR checks if status was already set and otherwise sets 400.