### PR TITLE
Add limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ serve(app, model, [options])
     (For more information, read the Mongoose docs:
     http://mongoosejs.com/docs/api.html#model_Model.findOneAndRemove)
   * **contextFilter** - `function(model, req, cb)`. Allows authorization per request, for example filtering items based on req.user. Defaults to `cb(model)`.
+  * **limit** - Set a limit for all queries except count queries. Can be overriden with the `limit` query parameter to a smaller value.
  * **postCreate** - A function with the signature `function (res, result, done)` which is run after document creation.
  * **postDelete** - A function with the signature `function (res, result, done)` which is run after document deletion.
 
@@ -262,6 +263,7 @@ restify.serve(app, MyModel, {
 * Jan Melcher (https://github.com/Yogu)
 * Urs Wolfer (https://github.com/uwolfer)
 * Thomas Forrer (https://github.com/forrert)
+* Stefan Kleeschulte (https://github.com/skleeschulte)
 
 ## Formalia
 

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -213,11 +213,10 @@ var restify = function(app, model, opts) {
     }
 
     function buildQuery(query, req) {
-        var options = queryOptions.clean,
-            excludedarr = filter.getExcluded(req.access);
+        var excludedarr = filter.getExcluded(req.access);
 
         var arr, i, re;
-        for (var key in options) {
+        for (var key in queryOptions.clean) {
             if (excludedarr.indexOf(key) !== -1) {
                 // caller tries to query for excluded keys. for security
                 // reasons, we will skip the first -1 objects (to provoke
@@ -226,7 +225,7 @@ var restify = function(app, model, opts) {
             }
 
             query.where(key);
-            var value = options[key];
+            var value = queryOptions.clean[key];
 
             if ('~' === value[0]) {
                 re = new RegExp(value.substring(1), 'i');
@@ -270,6 +269,11 @@ var restify = function(app, model, opts) {
 
         if (queryOptions.current.skip) {
             query.skip(queryOptions.current.skip);
+        }
+        if (options.limit && query.op !== 'count' &&
+            (!queryOptions.current.limit || queryOptions.current.limit > options.limit)) {
+            
+            queryOptions.current.limit = options.limit;
         }
         if (queryOptions.current.limit) {
             query.limit(queryOptions.current.limit);

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
         },
         {
             "name": "Thomas Forrer"
+        },
+        {
+            "name": "Stefan Kleeschulte"
         }
     ],
     "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -1590,6 +1590,89 @@ module.exports = function(createFn) {
                     });
                 });
             });
+            
+            describe('limit option', function () {
+                var server,
+                    app = createFn();
+        
+                setup();
+            
+                before(function (done) {
+                    erm.defaults({
+                        restify: app.isRestify,
+                        outputFn: app.outputFn,
+                        limit: 2
+                    });
+                    erm.serve(app, setup.customerModel);
+                
+                    setup.customerModel.create(
+                        { name: 'A' },
+                        { name: 'B' },
+                        { name: 'C' },
+                        function(err) {
+                            if (err) {
+                                done(err);
+                            }
+                            server = app.listen(testPort, done);
+                        }
+                    );
+                });
+        
+                after(function (done) {
+                    if (app.close) {
+                        return app.close(done);
+                    }
+                    server.close(done);
+                });
+            
+                it('limit: GET Customers/count should return 3', function (done) {
+                    request.get({
+                        url: util.format('%s/api/v1/Customers/count', testUrl),
+                        json: true
+                    }, function (err, res, body) {
+                        assert.equal(res.statusCode, 200, 'Wrong status code');
+                        assert.equal(body.count, 3, 'Wrong count');
+                        done();
+                    });
+                });
+            
+                it('limit: GET Customers should return 2 objects', function (done) {
+                    request.get({
+                        url: util.format('%s/api/v1/Customers', testUrl),
+                        json: true
+                    }, function (err, res, body) {
+                        assert.equal(res.statusCode, 200, 'Wrong status code');
+                        assert.ok(Array.isArray(body), 'Body is not an array');
+                        assert.equal(body.length, 2, 'Wrong count');
+                        done();
+                    });
+                });
+                
+                it('limit: GET Customers should return 2 objects', function (done) {
+                    request.get({
+                        url: util.format('%s/api/v1/Customers?limit=3', testUrl),
+                        json: true
+                    }, function (err, res, body) {
+                        assert.equal(res.statusCode, 200, 'Wrong status code');
+                        assert.ok(Array.isArray(body), 'Body is not an array');
+                        assert.equal(body.length, 2, 'Wrong count');
+                        done();
+                    });
+                });
+            
+                it('limit: GET Customers should return 1 object', function (done) {
+                    request.get({
+                        url: util.format('%s/api/v1/Customers?limit=1', testUrl),
+                        json: true
+                    }, function (err, res, body) {
+                        assert.equal(res.statusCode, 200, 'Wrong status code');
+                        assert.ok(Array.isArray(body), 'Body is not an array');
+                        assert.equal(body.length, 1, 'Wrong count');
+                        done();
+                    });
+                });
+        
+            });
 
             describe('postCreate', function() {
                 var server,


### PR DESCRIPTION
I added a limit option. This is useful to prevent huge result sets being returned and to enforce pagination (with skip and limit query parameters).

Exampel: `{ limit: 10 }` in the options object will limit all queries (except count queries) to 10. If a limit query parameter is supplied, it can only override this limit with a smaller number.

Tests are included. What do you think? :)