### PR TITLE
feat: allow array of private/protected fields

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -87,9 +87,13 @@ var restify = function(app, model, opts) {
         }
     }
 
-    options.private = options.private ? options.private.split(',') : [];
-    options.protected = options.protected ?
-        options.protected.split(',') : [];
+    if (!_.isArray(options.private)) {
+        options.private = options.private ? options.private.split(',') : [];
+    }
+    
+    if (!_.isArray(options.protected)) {
+        options.protected = options.protected ? options.protected.split(',') : [];
+    }
 
     model.schema.eachPath(function(name, path) {
         if (path.options.access) {


### PR DESCRIPTION
Simple change to allow passing an array of fields to `options.private` and `options.protected` rather than a comma-separated list of fields.