### PR TITLE
feat: custom method chaining

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -795,6 +795,12 @@ var restify = function(app, model, opts) {
             });
         }
     }, postProcess);
+
+    if (usingExpress && _.isFunction(require('express').Router)) {
+        var uriItemsRouter = new require('express').Router();
+        app.use(uri_items, uriItemsRouter);
+        return uriItemsRouter;
+    }
 };
 
 


### PR DESCRIPTION
It will only work with Express 4 and allows this:

```javascript
restify.serve(router, TransactionModel, {
  ...
}).get('/:id/refund', function(req, res, next) {
  // /api/v1/transactions/:id/refund
  res.status(200).send(req.params.id);
});
```

Improvements welcome, I'm not sure how or if this could be achieved with Express 3 or restify.

Either way, tests must be added before merging.