### PR TITLE
Add the runValidators option to findOneAndUpdate call.

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -498,7 +498,8 @@ var restify = function (app, model, opts) {
     if (options.findOneAndUpdate) {
       contextFilter(model, req, function (filteredContext) {
         findById(filteredContext, req.params.id).findOneAndUpdate({}, req.body, {
-          new: true
+          new: true,
+          runValidators: true
         }, function (err, item) {
           if (err) {
             err.status = 400


### PR DESCRIPTION
To support field validation on atomic updates without performing a non-atomic find and save.