### PR TITLE
chore(deps): depend on latest mongoose minor

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "dependencies": {
         "inflection": "~1.7.0",
         "lodash": "~3.10.0",
-        "mongoose": "~4.0.0"
+        "mongoose": "^4.0.0"
     },
     "description": "Easily restify mongoose database",
     "devDependencies": {


### PR DESCRIPTION
Since mongoose has switched to semver since version 4, this is now safe.