### PR TITLE
Allow unspecified properties to be saved when schema's strict option is set to false.

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -529,7 +529,7 @@ var restify = function (app, model, opts) {
             onError(err, req, res, next)
           } else {
             for (var key in req.body) {
-              doc[key] = req.body[key]
+              doc.set(key, req.body[key])
             }
             doc.save(function (err, item) {
               if (err) {


### PR DESCRIPTION
Fixes so that unspecified properties aren't ignored when saving to db.

http://mongoosejs.com/docs/guide.html#strict