### PR TITLE
escape regex string value in jsonQueryParser

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -338,7 +338,7 @@ var restify = function (app, model, opts) {
   function jsonQueryParser (key, value) {
     if (_.isString(value)) {
       if (value[0] === '~') { // parse RegExp
-        return new RegExp(value.substring(1), 'i')
+        return new RegExp(value.substring(1).replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1"), 'i')
       } else if (value[0] === '>') {
         if (value[1] === '=') {
           return {$gte: value.substr(2)}

--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -338,7 +338,7 @@ var restify = function (app, model, opts) {
   function jsonQueryParser (key, value) {
     if (_.isString(value)) {
       if (value[0] === '~') { // parse RegExp
-        return new RegExp(value.substring(1).replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1"), 'i')
+        return new RegExp(value.substring(1).replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1'), 'i')
       } else if (value[0] === '>') {
         if (value[1] === '=') {
           return {$gte: value.substr(2)}


### PR DESCRIPTION
Just a quick fix to allow regex queries with protected characters in them like '+'.

Example: http://.../api/v1/entity/?email=~pedro+test@gmail.com

Hope it helps.
pedro