### PR TITLE
refactor(onError): only send status code

### DIFF
--- a/lib/middleware/onError.js
+++ b/lib/middleware/onError.js
@@ -1,11 +1,13 @@
+var http = require('http')
+
 module.exports = function (isExpress) {
   return function (err, req, res, next) {
-    res.setHeader('Content-Type', 'application/json')
+    err.statusCode = err.statusCode || 500
 
     if (isExpress) {
-      res.status(err.statusCode || 500).json(err)
+      res.sendStatus(err.statusCode)
     } else {
-      res.send(err.statusCode || 500, JSON.parse(JSON.stringify(err)))
+      res.send(err.statusCode, http.STATUS_CODES[err.statusCode])
     }
   }
 }

--- a/test/unit/middleware/onError.js
+++ b/test/unit/middleware/onError.js
@@ -4,51 +4,43 @@ describe('onError', function () {
   var onError = require('../../../lib/middleware/onError')
 
   var res = {
-    setHeader: function () {},
-    status: function () {
+    sendStatus: function () {
       return this
     },
-    json: function () {},
     send: function () {}
   }
 
-  var setHeader = sinon.spy(res, 'setHeader')
-  var status = sinon.spy(res, 'status')
+  var sendStatus = sinon.spy(res, 'sendStatus')
   var send = sinon.spy(res, 'send')
-  var json = sinon.spy(res, 'json')
   var next = sinon.spy()
 
-  var err = new Error('An error occurred')
-  err.statusCode = 400
-
   afterEach(function () {
-    setHeader.reset()
-    status.reset()
+    sendStatus.reset()
     send.reset()
-    json.reset()
     next.reset()
   })
 
   it('with express', function () {
+    var err = new Error('An error occurred')
+    err.statusCode = 400
+
     onError(true)(err, {}, res, next)
 
-    sinon.assert.calledOnce(setHeader)
-    sinon.assert.calledWithExactly(setHeader, 'Content-Type', 'application/json')
-    sinon.assert.calledOnce(status)
-    sinon.assert.calledWithExactly(status, err.statusCode)
-    sinon.assert.calledOnce(json)
-    sinon.assert.calledWithExactly(json, err)
+    sinon.assert.calledOnce(sendStatus)
+    sinon.assert.calledWithExactly(sendStatus, 400)
+    sinon.assert.notCalled(send)
     sinon.assert.notCalled(next)
   })
 
   it('with restify', function () {
+    var err = new Error('An error occurred')
+    err.statusCode = 400
+
     onError(false)(err, {}, res, next)
 
-    sinon.assert.calledOnce(setHeader)
-    sinon.assert.calledWithExactly(setHeader, 'Content-Type', 'application/json')
-    sinon.assert.notCalled(status)
     sinon.assert.calledOnce(send)
-    sinon.assert.calledWithExactly(send, err.statusCode, JSON.parse(JSON.stringify(err)))
+    sinon.assert.calledWithExactly(send, 400, 'Bad Request')
+    sinon.assert.notCalled(sendStatus)
     sinon.assert.notCalled(next)
   })
 })


### PR DESCRIPTION
This makes for a safer default by avoiding to leak details about the database. If the developer wants to send more details to the client, then a custom error handler should be implemented.