### PR TITLE
feat: preCreate/Read/Update/Delete middleware

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -18,6 +18,10 @@ function getDefaults () {
     restify: false,
     runValidators: false,
     preMiddleware: [],
+    preCreate: [],
+    preRead: [],
+    preUpdate: [],
+    preDelete: [],
     private: [],
     protected: [],
     postCreate: [],
@@ -63,8 +67,26 @@ var restify = function (app, model, opts) {
     options.preMiddleware = [options.preMiddleware]
   }
 
+  if (!_.isArray(options.preCreate)) {
+    options.preCreate = [options.preCreate]
+  }
+
+  if (!_.isArray(options.preRead)) {
+    options.preRead = [options.preRead]
+  }
+
+  if (!_.isArray(options.preUpdate)) {
+    options.preUpdate = [options.preUpdate]
+  }
+
+  if (!_.isArray(options.preDelete)) {
+    options.preDelete = [options.preDelete]
+  }
+
   if (options.access) {
-    options.preMiddleware.push(access(options))
+    options.preCreate.push(access(options))
+    options.preRead.push(access(options))
+    options.preUpdate.push(access(options))
   }
 
   if (!options.contextFilter) {
@@ -127,18 +149,18 @@ var restify = function (app, model, opts) {
     next()
   })
 
-  app.get(uri_items, prepareQuery, options.preMiddleware, ops.getItems, prepareOutput)
-  app.get(uri_count, prepareQuery, options.preMiddleware, ops.getCount, prepareOutput)
-  app.get(uri_item, prepareQuery, options.preMiddleware, ops.getItem, prepareOutput)
-  app.get(uri_shallow, prepareQuery, options.preMiddleware, ops.getShallow, prepareOutput)
+  app.get(uri_items, prepareQuery, options.preMiddleware, options.preRead, ops.getItems, prepareOutput)
+  app.get(uri_count, prepareQuery, options.preMiddleware, options.preRead, ops.getCount, prepareOutput)
+  app.get(uri_item, prepareQuery, options.preMiddleware, options.preRead, ops.getItem, prepareOutput)
+  app.get(uri_shallow, prepareQuery, options.preMiddleware, options.preRead, ops.getShallow, prepareOutput)
 
-  app.post(uri_items, ensureContentType, options.preMiddleware, ops.createObject, prepareOutput)
-  app.post(uri_item, ensureContentType, options.preMiddleware, ops.modifyObject, prepareOutput)
+  app.post(uri_items, ensureContentType, options.preMiddleware, options.preCreate, ops.createObject, prepareOutput)
+  app.post(uri_item, ensureContentType, options.preMiddleware, options.preUpdate, ops.modifyObject, prepareOutput)
 
-  app.put(uri_item, ensureContentType, options.preMiddleware, ops.modifyObject, prepareOutput)
+  app.put(uri_item, ensureContentType, options.preMiddleware, options.preUpdate, ops.modifyObject, prepareOutput)
 
-  app.delete(uri_items, options.preMiddleware, ops.deleteItems, prepareOutput)
-  app.delete(uri_item, options.preMiddleware, ops.deleteItem, prepareOutput)
+  app.delete(uri_items, options.preMiddleware, options.preDelete, ops.deleteItems, prepareOutput)
+  app.delete(uri_item, options.preMiddleware, options.preDelete, ops.deleteItem, prepareOutput)
 
   return uri_items
 }


### PR DESCRIPTION
This adds: preCreate, preRead, preUpdate and preDelete middleware.

- `preMiddleware` > `preCreate/Read/Update` -> `access`
- `preMiddleware` > `preDelete`

This also paves the way for implementing #148 