### PR TITLE
fix(filter): check if schema and path are defined

### DIFF
--- a/lib/resource_filter.js
+++ b/lib/resource_filter.js
@@ -96,16 +96,24 @@ module.exports = function (model, filteredKeys) {
       currSchema = currSchema.path(fieldArray[i]).schema
     }
 
+    if (!currSchema) {
+      return
+    }
+
     var path = currSchema.path(fieldArray[fieldArray.length - 1])
 
-    if (!path && model.discriminators) {
-      _.each(model.discriminators, function (d) {
-        if (path) {
-          return
-        }
-
-        path = d.schema.path(fieldArray[fieldArray.length - 1])
-      })
+    if (!path) {
+      if (model.discriminators) {
+        _.each(model.discriminators, function (d) {
+          if (path) {
+            return
+          }
+  
+          path = d.schema.path(fieldArray[fieldArray.length - 1])
+        })
+      } else {
+        return
+      }
     }
 
     if (path.caster && path.caster.options) {

--- a/test/integration/read.js
+++ b/test/integration/read.js
@@ -796,6 +796,40 @@ module.exports = function (createFn, setup, dismantle) {
         })
       })
 
+      it('GET /Invoices?populate=customer.account 200 - ignore deep populate', function (done) {
+        request.get({
+          url: util.format('%s/api/v1/Invoices', testUrl),
+          qs: {
+            populate: 'customer.account'
+          },
+          json: true
+        }, function (err, res, body) {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 3)
+          body.forEach(function (invoice) {
+            assert.ok(invoice.customer)
+            assert.equal(typeof invoice.customer, 'string')
+          })
+          done()
+        })
+      })
+
+      it('GET /Invoices?populate=evilCustomer 200 - ignore unknown field', function (done) {
+        request.get({
+          url: util.format('%s/api/v1/Invoices', testUrl),
+          qs: {
+            populate: 'evilCustomer'
+          },
+          json: true
+        }, function (err, res, body) {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 3)
+          done()
+        })
+      })
+
       describe('with select', function () {
         it('GET Invoices?populate=customer&select=amount 200 - only include amount and customer document', function (done) {
           request.get({

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -22,6 +22,7 @@ module.exports = function () {
     Schema.apply(this, arguments)
 
     this.add({
+      account: { type: Schema.Types.ObjectId, ref: 'Account' },
       name: { type: String, required: true, unique: true },
       // friendlyId: { type: String, unique: true },
       comment: String,


### PR DESCRIPTION
`currSchema` is undefined when trying to do a deep populate (unsupported by mongoose)

`path` is undefined if the field doesn't exist

In both cases, it is safe to ignore the filtering since there is no data.

Closes #174 and #160 