### PR TITLE
feat: provide doc to preUpdate/Delete when findOneAnd* is false

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -37,6 +37,7 @@ var restify = function (app, model, opts) {
 
   var access = require('./middleware/access')
   var ensureContentType = require('./middleware/ensureContentType')(options)
+  var filterAndFindById = require('./middleware/filterAndFindById')(model, options)
   var onError = require('./middleware/onError')
   var outputFn = require('./middleware/outputFn')
   var prepareQuery = require('./middleware/prepareQuery')(options)
@@ -79,8 +80,16 @@ var restify = function (app, model, opts) {
     options.preUpdate = [options.preUpdate]
   }
 
+  if (!options.findOneAndUpdate) {
+    options.preUpdate.splice(0, 0, filterAndFindById)
+  }
+
   if (!_.isArray(options.preDelete)) {
     options.preDelete = [options.preDelete]
+  }
+
+  if (!options.findOneAndRemove) {
+    options.preDelete.splice(0, 0, filterAndFindById)
   }
 
   if (options.access) {

--- a/lib/middleware/filterAndFindById.js
+++ b/lib/middleware/filterAndFindById.js
@@ -1,0 +1,31 @@
+var http = require('http')
+
+module.exports = function (model, options) {
+  return function (req, res, next) {
+    if (!req.params.id) {
+      return next()
+    }
+
+    options.contextFilter(model, req, function (filteredContext) {
+      var byId = {}
+      byId[options.idProperty] = req.params.id
+
+      filteredContext.findOne().and(byId).lean(false).exec(function (err, doc) {
+        if (err) {
+          err.statusCode = 400
+          return options.onError(err, req, res, next)
+        }
+
+        if (!doc) {
+          err = new Error(http.STATUS_CODES[404])
+          err.statusCode = 404
+          return options.onError(err, req, res, next)
+        }
+
+        req.erm.document = doc
+
+        next()
+      })
+    })
+  }
+}

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -158,30 +158,15 @@ module.exports = function (model, options) {
         })
       })
     } else {
-      options.contextFilter(model, req, function (filteredContext) {
-        findById(filteredContext, req.params.id).exec(function (err, doc) {
-          if (err) {
-            err.statusCode = 400
-            return options.onError(err, req, res, next)
-          }
+      req.erm.document.remove(function (err, result) {
+        if (err) {
+          err.statusCode = 400
+          return options.onError(err, req, res, next)
+        }
 
-          if (!doc) {
-            err = new Error(http.STATUS_CODES[404])
-            err.statusCode = 404
-            return options.onError(err, req, res, next)
-          }
+        req.erm.statusCode = 204
 
-          doc.remove(function (err, result) {
-            if (err) {
-              err.statusCode = 400
-              return options.onError(err, req, res, next)
-            }
-
-            req.erm.statusCode = 204
-
-            next()
-          })
-        })
+        next()
       })
     }
   }
@@ -331,41 +316,26 @@ module.exports = function (model, options) {
         })
       })
     } else {
-      options.contextFilter(model, req, function (filteredContext) {
-        findById(filteredContext, req.params.id).exec(function (err, doc) {
-          if (err) {
-            err.statusCode = 400
-            return options.onError(err, req, res, next)
-          }
+      for (var key in cleanBody) {
+        req.erm.document.set(key, cleanBody[key])
+      }
 
-          if (!doc) {
-            err = new Error(http.STATUS_CODES[404])
-            err.statusCode = 404
-            return options.onError(err, req, res, next)
-          }
+      req.erm.document.save(function (err, item) {
+        if (err) {
+          err.statusCode = 400
+          return options.onError(err, req, res, next)
+        }
 
-          for (var key in cleanBody) {
-            doc.set(key, cleanBody[key])
-          }
+        model.populate(item, req._ermQueryOptions.populate || []).then(function (item) {
+          item = filter.filterObject(item, filterOpts)
 
-          doc.save(function (err, item) {
-            if (err) {
-              err.statusCode = 400
-              return options.onError(err, req, res, next)
-            }
+          req.erm.result = item
+          req.erm.statusCode = 200
 
-            model.populate(item, req._ermQueryOptions.populate || []).then(function (item) {
-              item = filter.filterObject(item, filterOpts)
-
-              req.erm.result = item
-              req.erm.statusCode = 200
-
-              next()
-            }, function (err) {
-              err.statusCode = 400
-              return options.onError(err, req, res, next)
-            })
-          })
+          next()
+        }, function (err) {
+          err.statusCode = 400
+          return options.onError(err, req, res, next)
         })
       })
     }

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -17,12 +17,7 @@ module.exports = function (model, options) {
 
   function getItems (req, res, next) {
     options.contextFilter(model, req, function (filteredContext) {
-      buildQuery(filteredContext.find(), req._ermQueryOptions).lean(options.lean).exec(function (err, items) {
-        if (err) {
-          err.statusCode = 400
-          return options.onError(err, req, res, next)
-        }
-
+      buildQuery(filteredContext.find(), req._ermQueryOptions).lean(options.lean).exec().then(function (items) {
         var populate = req._ermQueryOptions.populate
         var opts = {
           populate: populate,
@@ -35,36 +30,32 @@ module.exports = function (model, options) {
         req.erm.statusCode = 200
 
         next()
+      }, function (err) {
+        err.statusCode = 400
+        options.onError(err, req, res, next)
       })
     })
   }
 
   function getCount (req, res, next) {
     options.contextFilter(model, req, function (filteredContext) {
-      buildQuery(filteredContext.count(), req._ermQueryOptions).exec(function (err, count) {
-        if (err) {
-          err.statusCode = 400
-          return options.onError(err, req, res, next)
-        }
-
+      buildQuery(filteredContext.count(), req._ermQueryOptions).exec().then(function (count) {
         req.erm.result = { count: count }
         req.erm.statusCode = 200
 
         next()
+      }, function (err) {
+        err.statusCode = 400
+        options.onError(err, req, res, next)
       })
     })
   }
 
   function getShallow (req, res, next) {
     options.contextFilter(model, req, function (filteredContext) {
-      buildQuery(findById(filteredContext, req.params.id), req._ermQueryOptions).lean(options.lean).exec(function (err, item) {
-        if (err) {
-          err.statusCode = 400
-          return options.onError(err, req, res, next)
-        }
-
+      buildQuery(findById(filteredContext, req.params.id), req._ermQueryOptions).lean(options.lean).exec().then(function (item) {
         if (!item) {
-          err = new Error(http.STATUS_CODES[404])
+          var err = new Error(http.STATUS_CODES[404])
           err.statusCode = 404
           return options.onError(err, req, res, next)
         }
@@ -85,35 +76,31 @@ module.exports = function (model, options) {
         req.erm.statusCode = 200
 
         next()
+      }, function (err) {
+        err.statusCode = 400
+        options.onError(err, req, res, next)
       })
     })
   }
 
   function deleteItems (req, res, next) {
     options.contextFilter(model, req, function (filteredContext) {
-      buildQuery(filteredContext.find(), req._ermQueryOptions).remove(function (err, items) {
-        if (err) {
-          err.statusCode = 400
-          return options.onError(err, req, res, next)
-        }
-
+      buildQuery(filteredContext.find(), req._ermQueryOptions).remove().then(function () {
         req.erm.statusCode = 204
 
         next()
+      }, function (err) {
+        err.statusCode = 400
+        options.onError(err, req, res, next)
       })
     })
   }
 
   function getItem (req, res, next) {
     options.contextFilter(model, req, function (filteredContext) {
-      buildQuery(findById(filteredContext, req.params.id), req._ermQueryOptions).lean(options.lean).exec(function (err, item) {
-        if (err) {
-          err.statusCode = 400
-          return options.onError(err, req, res, next)
-        }
-
+      buildQuery(findById(filteredContext, req.params.id), req._ermQueryOptions).lean(options.lean).exec().then(function (item) {
         if (!item) {
-          err = new Error(http.STATUS_CODES[404])
+          var err = new Error(http.STATUS_CODES[404])
           err.statusCode = 404
           return options.onError(err, req, res, next)
         }
@@ -130,6 +117,9 @@ module.exports = function (model, options) {
         req.erm.statusCode = 200
 
         next()
+      }, function (err) {
+        err.statusCode = 400
+        options.onError(err, req, res, next)
       })
     })
   }
@@ -140,14 +130,9 @@ module.exports = function (model, options) {
 
     if (options.findOneAndRemove) {
       options.contextFilter(model, req, function (filteredContext) {
-        findById(filteredContext, req.params.id).findOneAndRemove(function (err, doc) {
-          if (err) {
-            err.statusCode = 400
-            return options.onError(err, req, res, next)
-          }
-
-          if (!doc) {
-            err = new Error(http.STATUS_CODES[404])
+        findById(filteredContext, req.params.id).findOneAndRemove().then(function (item) {
+          if (!item) {
+            var err = new Error(http.STATUS_CODES[404])
             err.statusCode = 404
             return options.onError(err, req, res, next)
           }
@@ -155,18 +140,19 @@ module.exports = function (model, options) {
           req.erm.statusCode = 204
 
           next()
+        }, function (err) {
+          err.statusCode = 400
+          options.onError(err, req, res, next)
         })
       })
     } else {
-      req.erm.document.remove(function (err, result) {
-        if (err) {
-          err.statusCode = 400
-          return options.onError(err, req, res, next)
-        }
-
+      req.erm.document.remove().then(function () {
         req.erm.statusCode = 204
 
         next()
+      }, function (err) {
+        err.statusCode = 400
+        options.onError(err, req, res, next)
       })
     }
   }
@@ -187,23 +173,18 @@ module.exports = function (model, options) {
       delete req.body[model.schema.options.versionKey]
     }
 
-    model.create(req.body, function (err, item) {
-      if (err) {
-        err.statusCode = 400
-        return options.onError(err, req, res, next)
-      }
+    model.create(req.body).then(function (item) {
+      return model.populate(item, req._ermQueryOptions.populate || [])
+    }).then(function (item) {
+      item = filter.filterObject(item, filterOpts)
 
-      model.populate(item, req._ermQueryOptions.populate || []).then(function (item) {
-        item = filter.filterObject(item, filterOpts)
+      req.erm.result = item
+      req.erm.statusCode = 201
 
-        req.erm.result = item
-        req.erm.statusCode = 201
-
-        next()
-      }, function (err) {
-        err.statusCode = 400
-        return options.onError(err, req, res, next)
-      })
+      next()
+    }, function (err) {
+      err.statusCode = 400
+      options.onError(err, req, res, next)
     })
   }
 
@@ -290,43 +271,15 @@ module.exports = function (model, options) {
         }, {
           new: true,
           runValidators: options.runValidators
-        }, function (err, item) {
-          if (err) {
-            err.statusCode = 400
-            return options.onError(err, req, res, next)
-          }
-
+        }).exec().then(function (item) {
+          return model.populate(item, req._ermQueryOptions.populate || [])
+        }).then(function (item) {
           if (!item) {
-            err = new Error(http.STATUS_CODES[404])
+            var err = new Error(http.STATUS_CODES[404])
             err.statusCode = 404
             return options.onError(err, req, res, next)
           }
 
-          model.populate(item, req._ermQueryOptions.populate || []).then(function (item) {
-            item = filter.filterObject(item, filterOpts)
-
-            req.erm.result = item
-            req.erm.statusCode = 200
-
-            next()
-          }, function (err) {
-            err.statusCode = 400
-            return options.onError(err, req, res, next)
-          })
-        })
-      })
-    } else {
-      for (var key in cleanBody) {
-        req.erm.document.set(key, cleanBody[key])
-      }
-
-      req.erm.document.save(function (err, item) {
-        if (err) {
-          err.statusCode = 400
-          return options.onError(err, req, res, next)
-        }
-
-        model.populate(item, req._ermQueryOptions.populate || []).then(function (item) {
           item = filter.filterObject(item, filterOpts)
 
           req.erm.result = item
@@ -335,8 +288,26 @@ module.exports = function (model, options) {
           next()
         }, function (err) {
           err.statusCode = 400
-          return options.onError(err, req, res, next)
+          options.onError(err, req, res, next)
         })
+      })
+    } else {
+      for (var key in cleanBody) {
+        req.erm.document.set(key, cleanBody[key])
+      }
+
+      req.erm.document.save().then(function (item) {
+        return model.populate(item, req._ermQueryOptions.populate || [])
+      }).then(function (item) {
+        item = filter.filterObject(item, filterOpts)
+
+        req.erm.result = item
+        req.erm.statusCode = 200
+
+        next()
+      }, function (err) {
+        err.statusCode = 400
+        options.onError(err, req, res, next)
       })
     }
   }

--- a/test/integration/middleware.js
+++ b/test/integration/middleware.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var mongoose = require('mongoose')
 var request = require('request')
 var sinon = require('sinon')
 var util = require('util')
@@ -9,6 +10,8 @@ module.exports = function (createFn, setup, dismantle) {
 
   var testPort = 30023
   var testUrl = 'http://localhost:' + testPort
+  var invalidId = 'invalid-id'
+  var randomId = mongoose.Types.ObjectId().toHexString()
 
   describe('preMiddleware', function () {
     var app = createFn()
@@ -608,6 +611,20 @@ module.exports = function (createFn, setup, dismantle) {
         done()
       })
     })
+
+    it('POST /Customers 400 - missing required field', function (done) {
+      request.post({
+        url: util.format('%s/api/v1/Customers', testUrl),
+        json: {
+          comment: 'Bar'
+        }
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 400)
+        sinon.assert.notCalled(options.postCreate)
+        done()
+      })
+    })
   })
 
   describe('postRead', function () {
@@ -696,6 +713,30 @@ module.exports = function (createFn, setup, dismantle) {
       })
     })
 
+    it('GET /Customers/:id 404', function (done) {
+      request.get({
+        url: util.format('%s/api/v1/Customers/%s', testUrl, randomId),
+        json: true
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 404)
+        sinon.assert.notCalled(options.postRead)
+        done()
+      })
+    })
+
+    it('GET /Customers/:id 400', function (done) {
+      request.get({
+        url: util.format('%s/api/v1/Customers/%s', testUrl, invalidId),
+        json: true
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 400)
+        sinon.assert.notCalled(options.postRead)
+        done()
+      })
+    })
+
     it('GET /Customers/:id/shallow 200', function (done) {
       request.get({
         url: util.format('%s/api/v1/Customers/%s/shallow', testUrl, customer._id),
@@ -768,6 +809,34 @@ module.exports = function (createFn, setup, dismantle) {
       })
     })
 
+    it('POST /Customers/:id 404 - random id', function (done) {
+      request.post({
+        url: util.format('%s/api/v1/Customers/%s', testUrl, randomId),
+        json: {
+          name: 'Bobby'
+        }
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 404)
+        sinon.assert.notCalled(options.postUpdate)
+        done()
+      })
+    })
+
+    it('POST /Customers/:id 400 - invalid id', function (done) {
+      request.post({
+        url: util.format('%s/api/v1/Customers/%s', testUrl, invalidId),
+        json: {
+          name: 'Bobby'
+        }
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 400)
+        sinon.assert.notCalled(options.postUpdate)
+        done()
+      })
+    })
+
     it('POST /Customers/:id 400 - not called (missing content type)', function (done) {
       request.post({
         url: util.format('%s/api/v1/Customers/%s', testUrl, customer._id)
@@ -806,6 +875,34 @@ module.exports = function (createFn, setup, dismantle) {
         assert.equal(args[0].erm.result.name, 'Bobby')
         assert.equal(args[0].erm.statusCode, 200)
         assert.equal(typeof args[2], 'function')
+        done()
+      })
+    })
+
+    it('PUT /Customers/:id 404 - random id', function (done) {
+      request.put({
+        url: util.format('%s/api/v1/Customers/%s', testUrl, randomId),
+        json: {
+          name: 'Bobby'
+        }
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 404)
+        sinon.assert.notCalled(options.postUpdate)
+        done()
+      })
+    })
+
+    it('PUT /Customers/:id 400 - invalid id', function (done) {
+      request.put({
+        url: util.format('%s/api/v1/Customers/%s', testUrl, invalidId),
+        json: {
+          name: 'Bobby'
+        }
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 400)
+        sinon.assert.notCalled(options.postUpdate)
         done()
       })
     })
@@ -899,6 +996,30 @@ module.exports = function (createFn, setup, dismantle) {
         assert.equal(args[0].erm.result, undefined)
         assert.equal(args[0].erm.statusCode, 204)
         assert.equal(typeof args[2], 'function')
+        done()
+      })
+    })
+
+    it('DELETE /Customers/:id 404', function (done) {
+      request.del({
+        url: util.format('%s/api/v1/Customers/%s', testUrl, randomId),
+        json: true
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 404)
+        sinon.assert.notCalled(options.postDelete)
+        done()
+      })
+    })
+
+    it('DELETE /Customers/:id 400', function (done) {
+      request.del({
+        url: util.format('%s/api/v1/Customers/%s', testUrl, invalidId),
+        json: true
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 400)
+        sinon.assert.notCalled(options.postDelete)
         done()
       })
     })


### PR DESCRIPTION
This would give access to the document in `preUpdate` and `preDelete` middlewares when `findOneAnd* = false`

```javascript
findOneAndUpdate: false,
preUpdate: function (req, res, next) {
  if (req.erm.document.isAwesome) {
    return next()
  }

  res.sendStatus(403)
}
```

It also opens the door for doing clever things with delete:

```javascript
findOneAndRemove: false,
preDelete: function (req, res, next) {
  if (!req.erm.document) {
    return res.sendStatus(403) // probably don't want to delete everything
  }

  req.erm.document.set('deletedAt', new Date())

  req.erm.document.save(function (err) {
    res.sendStatus(204)
  })
}
```
Closes #148