### PR TITLE
fix: prevent defaults() from duplicating preUpdates/Deletes

### DIFF
--- a/lib/express-restify-mongoose.js
+++ b/lib/express-restify-mongoose.js
@@ -17,17 +17,8 @@ function getDefaults () {
     plural: true,
     restify: false,
     runValidators: false,
-    preMiddleware: [],
-    preCreate: [],
-    preRead: [],
-    preUpdate: [],
-    preDelete: [],
     private: [],
-    protected: [],
-    postCreate: [],
-    postRead: [],
-    postUpdate: [],
-    postDelete: []
+    protected: []
   })
 }
 
@@ -65,37 +56,23 @@ var restify = function (app, model, opts) {
   })
 
   if (!_.isArray(options.preMiddleware)) {
-    options.preMiddleware = [options.preMiddleware]
+    options.preMiddleware = options.preMiddleware ? [options.preMiddleware] : []
   }
 
   if (!_.isArray(options.preCreate)) {
-    options.preCreate = [options.preCreate]
+    options.preCreate = options.preCreate ? [options.preCreate] : []
   }
 
   if (!_.isArray(options.preRead)) {
-    options.preRead = [options.preRead]
+    options.preRead = options.preRead ? [options.preRead] : []
   }
 
   if (!_.isArray(options.preUpdate)) {
-    options.preUpdate = [options.preUpdate]
-  }
-
-  if (!options.findOneAndUpdate) {
-    options.preUpdate.splice(0, 0, filterAndFindById)
+    options.preUpdate = options.preUpdate ? [options.preUpdate] : []
   }
 
   if (!_.isArray(options.preDelete)) {
-    options.preDelete = [options.preDelete]
-  }
-
-  if (!options.findOneAndRemove) {
-    options.preDelete.splice(0, 0, filterAndFindById)
-  }
-
-  if (options.access) {
-    options.preCreate.push(access(options))
-    options.preRead.push(access(options))
-    options.preUpdate.push(access(options))
+    options.preDelete = options.preDelete ? [options.preDelete] : []
   }
 
   if (!options.contextFilter) {
@@ -105,19 +82,19 @@ var restify = function (app, model, opts) {
   }
 
   if (!_.isArray(options.postCreate)) {
-    options.postCreate = [options.postCreate]
+    options.postCreate = options.postCreate ? [options.postCreate] : []
   }
 
   if (!_.isArray(options.postRead)) {
-    options.postRead = [options.postRead]
+    options.postRead = options.postRead ? [options.postRead] : []
   }
 
   if (!_.isArray(options.postUpdate)) {
-    options.postUpdate = [options.postUpdate]
+    options.postUpdate = options.postUpdate ? [options.postUpdate] : []
   }
 
   if (!_.isArray(options.postDelete)) {
-    options.postDelete = [options.postDelete]
+    options.postDelete = options.postDelete ? [options.postDelete] : []
   }
 
   if (!options.onError) {
@@ -158,18 +135,20 @@ var restify = function (app, model, opts) {
     next()
   })
 
-  app.get(uri_items, prepareQuery, options.preMiddleware, options.preRead, ops.getItems, prepareOutput)
-  app.get(uri_count, prepareQuery, options.preMiddleware, options.preRead, ops.getCount, prepareOutput)
-  app.get(uri_item, prepareQuery, options.preMiddleware, options.preRead, ops.getItem, prepareOutput)
-  app.get(uri_shallow, prepareQuery, options.preMiddleware, options.preRead, ops.getShallow, prepareOutput)
+  var accessMiddleware = options.access ? access(options) : []
 
-  app.post(uri_items, prepareQuery, ensureContentType, options.preMiddleware, options.preCreate, ops.createObject, prepareOutput)
-  app.post(uri_item, prepareQuery, ensureContentType, options.preMiddleware, options.preUpdate, ops.modifyObject, prepareOutput)
+  app.get(uri_items, prepareQuery, options.preMiddleware, options.preRead, accessMiddleware, ops.getItems, prepareOutput)
+  app.get(uri_count, prepareQuery, options.preMiddleware, options.preRead, accessMiddleware, ops.getCount, prepareOutput)
+  app.get(uri_item, prepareQuery, options.preMiddleware, options.preRead, accessMiddleware, ops.getItem, prepareOutput)
+  app.get(uri_shallow, prepareQuery, options.preMiddleware, options.preRead, accessMiddleware, ops.getShallow, prepareOutput)
 
-  app.put(uri_item, prepareQuery, ensureContentType, options.preMiddleware, options.preUpdate, ops.modifyObject, prepareOutput)
+  app.post(uri_items, prepareQuery, ensureContentType, options.preMiddleware, options.preCreate, accessMiddleware, ops.createObject, prepareOutput)
+  app.post(uri_item, prepareQuery, ensureContentType, options.preMiddleware, options.findOneAndUpdate ? [] : filterAndFindById, options.preUpdate, accessMiddleware, ops.modifyObject, prepareOutput)
+
+  app.put(uri_item, prepareQuery, ensureContentType, options.preMiddleware, options.findOneAndUpdate ? [] : filterAndFindById, options.preUpdate, accessMiddleware, ops.modifyObject, prepareOutput)
 
   app.delete(uri_items, options.preMiddleware, options.preDelete, ops.deleteItems, prepareOutput)
-  app.delete(uri_item, options.preMiddleware, options.preDelete, ops.deleteItem, prepareOutput)
+  app.delete(uri_item, options.preMiddleware, options.findOneAndRemove ? [] : filterAndFindById, options.preDelete, ops.deleteItem, prepareOutput)
 
   return uri_items
 }


### PR DESCRIPTION
Using `.defaults()` without an explicitly provided preUpdate
resulted in accidental duplication of findOneAndUpdate
when multiple models were attached.

Resolves [#182](https://github.com/florianholzapfel/express-restify-mongoose/issues/182)