### PR TITLE
Update - how to replace subdocs?

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "method-override": "~2",
     "mocha": "~2",
     "request": "~2",
+    "request-promise": "^1.0.2",
     "restify": "~3",
     "sinon": "~1",
     "standard": "^5.0.0"

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var mongoose = require('mongoose')
 var request = require('request')
+var requestPromise = require('request-promise')
 var util = require('util')
 
 module.exports = function (createFn, setup, dismantle) {
@@ -108,6 +109,45 @@ module.exports = function (createFn, setup, dismantle) {
           assert.equal(body.path, 'age')
           done()
         })
+      })
+
+      it('PUT /Customers/:id 200 - update subdocument `favorites`', function (done) {
+        var url = util.format('%s/api/v1/Customers/%s', testUrl, customers[0]._id)
+
+        Promise.resolve().then(function() {
+          return requestPromise({
+            url: url,
+            body: {
+              favorites: {
+                animal: 'Cat'
+              }
+            },
+            method: 'PUT',
+            json: true,
+            resolveWithFullResponse: true,
+          })
+        }).then(function(res) {
+          assert.equal(res.statusCode, 200)
+          assert.deepEqual(res.body.favorites, {animal: 'Cat'})
+
+          return requestPromise({
+            url: url,
+            body: {
+              favorites: {
+                color: 'blue'
+              }
+            },
+            method: 'PUT',
+            json: true,
+            resolveWithFullResponse: true,
+          })
+        })
+        .then(function(res) {
+          assert.equal(res.statusCode, 200)
+          assert.deepEqual(res.body.favorites, {color: 'blue'})
+        })
+        .then(done)
+        .catch(done)
       })
 
       it('POST /Customers/:id 400 - mongo error', function (done) {


### PR DESCRIPTION
This is not an actual PR - just a failing test showcasing a problem.

In my opinion - when updating subdocs we should force the sender to supply the full subdocument, otherwise we get problems with having old junk data and an inability to remove properties. It now does some kind of merge where it's unpredictable what you actually get afterwards.

I think [`flatten()`](https://github.com/florianholzapfel/express-restify-mongoose/blob/master/lib/operations.js#L237-L265) needs to go. What is the reason and benefit for doing the flattening?