### PR TITLE
4.3.1 embedded schema failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "async": "~1.5.0",
     "inflection": "~1.8.0",
-    "lodash": "~3.10.0"
+    "lodash": "~3.10.0",
+    "mongoose": "^4.3.1"
   },
   "peerDependencies": {
     "mongoose": "^4.0.0"
@@ -19,6 +20,7 @@
     "method-override": "~2",
     "mocha": "~2",
     "request": "~2",
+    "request-promise": "^1.0.2",
     "restify": "~3",
     "sinon": "~1",
     "standard": "^5.0.0"

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -13,6 +13,17 @@ module.exports = function () {
     price: { type: Number }
   })
 
+  var PurchaseSchema = new Schema({
+    item: { type: Schema.Types.ObjectId, ref: 'Product' },
+    number: { type: Number }
+  })
+
+  var FavoritesSchema = new Schema({
+    animal: { type: String },
+    color: { type: String },
+    purchase: PurchaseSchema
+  })
+
   var BaseCustomerSchema = function () {
     Schema.apply(this, arguments)
 
@@ -22,14 +33,7 @@ module.exports = function () {
       comment: { type: String },
       address: { type: String },
       age: { type: Number },
-      favorites: {
-        animal: { type: String },
-        color: { type: String },
-        purchase: {
-          item: { type: Schema.Types.ObjectId, ref: 'Product' },
-          number: { type: Number }
-        }
-      },
+      favorites: FavoritesSchema,
       purchases: [{
         item: { type: Schema.Types.ObjectId, ref: 'Product' },
         number: { type: Number }


### PR DESCRIPTION
Heya, I had some problems in my app that my updates didn't go through on my subdocs. I started digging and understood it was in express-restify or mongoose. 

Eventually realised the problem. I'm running Mongoose 4.3 where you can embed schemas ([got added in 4.2](http://mongoosejs.com/docs/subdocs.html)) .. and that that doesn't work that well in express-restify.

A bunch of other things started failing when I started using subdocs.

Restify should work with the refactored CustomerSchema below, shouldn't it?
