### PR TITLE
fix(query): run parseInt on skip and limit parameters

### DIFF
--- a/lib/middleware/prepareQuery.js
+++ b/lib/middleware/prepareQuery.js
@@ -119,6 +119,8 @@ module.exports = function (options) {
         } catch (e) {
           req._ermQueryOptions[key] = req.query[key]
         }
+      } else if (key === 'limit' || key === 'skip') {
+        req._ermQueryOptions[key] = parseInt(req.query[key], 10)
       } else {
         req._ermQueryOptions[key] = req.query[key]
       }

--- a/test/integration/delete.js
+++ b/test/integration/delete.js
@@ -102,6 +102,7 @@ module.exports = function (createFn, setup, dismantle) {
           assert.equal(res.statusCode, 204)
 
           db.models.Customer.find({}, function (err, customers) {
+            assert.ok(!err)
             assert.equal(customers.length, 2)
             customers.forEach(function (customer) {
               assert.ok(customer.name !== 'John')
@@ -201,6 +202,7 @@ module.exports = function (createFn, setup, dismantle) {
           assert.equal(res.statusCode, 204)
 
           db.models.Customer.find({}, function (err, customers) {
+            assert.ok(!err)
             assert.equal(customers.length, 2)
             customers.forEach(function (customer) {
               assert.ok(customer.name !== 'John')

--- a/test/integration/read.js
+++ b/test/integration/read.js
@@ -174,6 +174,21 @@ module.exports = function (createFn, setup, dismantle) {
           done()
         })
       })
+
+      it('GET /Customers?limit=foo 200 - evaluates to NaN', function (done) {
+        request.get({
+          url: util.format('%s/api/v1/Customers', testUrl),
+          qs: {
+            limit: 'foo'
+          },
+          json: true
+        }, function (err, res, body) {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 3)
+          done()
+        })
+      })
     })
 
     describe('skip', function () {
@@ -188,6 +203,21 @@ module.exports = function (createFn, setup, dismantle) {
           assert.ok(!err)
           assert.equal(res.statusCode, 200)
           assert.equal(body.length, 2)
+          done()
+        })
+      })
+
+      it('GET /Customers?skip=foo 200 - evaluates to NaN', function (done) {
+        request.get({
+          url: util.format('%s/api/v1/Customers', testUrl),
+          qs: {
+            skip: 'foo'
+          },
+          json: true
+        }, function (err, res, body) {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 3)
           done()
         })
       })


### PR DESCRIPTION
MongoDB 3.2 requires skip and limit to be numbers, so we must parse it internally.

Closes #215