### PR TITLE
feat: option to create with save

### DIFF
--- a/lib/operations.js
+++ b/lib/operations.js
@@ -185,7 +185,15 @@ module.exports = function (model, options) {
       delete req.body[model.schema.options.versionKey]
     }
 
-    model.create(req.body).then(function (item) {
+    var query
+
+    if (options.createWithSave) {
+      query = new model(req.body).save() // eslint-disable-line new-cap
+    } else {
+      query = model.create(req.body)
+    }
+
+    query.then(function (item) {
       return model.populate(item, req._ermQueryOptions.populate || [])
     }).then(function (item) {
       item = filter.filterObject(item, filterOpts)

--- a/test/integration/create.js
+++ b/test/integration/create.js
@@ -67,6 +67,7 @@ module.exports = function (createFn, setup, dismantle) {
         assert.equal(res.statusCode, 201)
         assert.ok(body._id)
         assert.equal(body.name, 'John')
+        assert.equal(body.postSave, undefined)
         done()
       })
     })
@@ -312,6 +313,46 @@ module.exports = function (createFn, setup, dismantle) {
         assert.equal(Object.keys(body.errors).length, 2)
         assert.ok(body.errors['customer'])
         assert.ok(body.errors['products'])
+        done()
+      })
+    })
+  })
+
+  describe('Create documents (createWithSave)', function () {
+    var app = createFn()
+    var server
+
+    beforeEach(function (done) {
+      setup(function (err) {
+        if (err) {
+          return done(err)
+        }
+
+        erm.serve(app, db.models.Product, {
+          restify: app.isRestify,
+          createWithSave: true
+        })
+
+        server = app.listen(testPort, done)
+      })
+    })
+
+    afterEach(function (done) {
+      dismantle(app, server, done)
+    })
+
+    it('POST /Products 201', function (done) {
+      request.post({
+        url: util.format('%s/api/v1/Products', testUrl),
+        json: {
+          name: 'John'
+        }
+      }, function (err, res, body) {
+        assert.ok(!err)
+        assert.equal(res.statusCode, 201)
+        assert.ok(body._id)
+        assert.equal(body.name, 'John')
+        assert.equal(body.postSave, 'postSave')
         done()
       })
     })

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -10,7 +10,12 @@ module.exports = function () {
       name: { type: String },
       code: { type: Number }
     },
-    price: { type: Number }
+    price: { type: Number },
+    postSave: { type: String }
+  })
+
+  ProductSchema.post('save', function () {
+    this.postSave = 'postSave'
   })
 
   var BaseCustomerSchema = function () {


### PR DESCRIPTION
**Work in progress**

See issue #213

This should allow running mongoose middleware when creating objects. Same idea as `findOneAndUpdate` and `findOneAndRemove` options.

``` js
erm.serve(router, 'Model', {
  createWithSave: true
})
```

_To do_
- [ ] Write tests
