### PR TITLE
fix(distinct): filter private/protected keys

### DIFF
--- a/src/express-restify-mongoose.js
+++ b/src/express-restify-mongoose.js
@@ -111,7 +111,7 @@ const restify = function (app, model, opts = {}) {
 
   options.name = options.name || model.modelName
 
-  const ops = require('./operations')(model, options)
+  const ops = require('./operations')(model, options, excludedMap)
 
   let uri_item = `${options.prefix}${options.version}/${options.name}`
   if (uri_item.indexOf('/:id') === -1) {

--- a/src/resource_filter.js
+++ b/src/resource_filter.js
@@ -5,7 +5,7 @@ const weedout = require('weedout')
 /**
  * Represents a filter.
  * @constructor
- * @param {Object} - Options
+ * @param {Object} opts - Options
  * @param {Object} opts.model - Mongoose model
  * @param {Object} opts.excludedMap {} - Filtered keys for related models
  * @param {Object} opts.filteredKeys {} - Keys to filter for the current model
@@ -58,6 +58,21 @@ Filter.prototype.getExcluded = function (opts) {
   }
 
   return opts.access === 'protected' ? entry.private : entry.private.concat(entry.protected)
+}
+
+Filter.prototype.isExcluded = function (field, opts) {
+  if (!field) {
+    return false
+  }
+
+  opts = _.defaults(opts, {
+    access: 'public',
+    excludedMap: {},
+    filteredKeys: this.filteredKeys,
+    modelName: this.model.modelName
+  })
+
+  return this.getExcluded(opts).indexOf(field) >= 0
 }
 
 /**

--- a/test/integration/access.js
+++ b/test/integration/access.js
@@ -167,6 +167,38 @@ module.exports = function (createFn, setup, dismantle) {
         })
       })
 
+      it('GET /Customer?distinct=age 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer`,
+          qs: {
+            distinct: 'age'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 1)
+          assert.equal(body[0], 12)
+          done()
+        })
+      })
+
+      it('GET /Customer?distinct=comment 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer`,
+          qs: {
+            distinct: 'comment'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 1)
+          assert.equal(body[0], 'Boo')
+          done()
+        })
+      })
+
       it('GET /Customer/:id 200', (done) => {
         request.get({
           url: `${testUrl}/api/v1/Customer/${customer._id}`,
@@ -186,6 +218,38 @@ module.exports = function (createFn, setup, dismantle) {
               number: 1
             }
           })
+          done()
+        })
+      })
+
+      it('GET /Customer/:id?distinct=age 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer/${customer._id}`,
+          qs: {
+            distinct: 'age'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 1)
+          assert.equal(body[0], 12)
+          done()
+        })
+      })
+
+      it('GET /Customer/:id?distinct=comment 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer/${customer._id}`,
+          qs: {
+            distinct: 'comment'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 1)
+          assert.equal(body[0], 'Boo')
           done()
         })
       })
@@ -629,6 +693,37 @@ module.exports = function (createFn, setup, dismantle) {
         })
       })
 
+      it('GET /Customer?distinct=age 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer`,
+          qs: {
+            distinct: 'age'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 0)
+          done()
+        })
+      })
+
+      it('GET /Customer?distinct=comment 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer`,
+          qs: {
+            distinct: 'comment'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 1)
+          assert.equal(body[0], 'Boo')
+          done()
+        })
+      })
+
       it('GET /Customer/:id 200', (done) => {
         request.get({
           url: `${testUrl}/api/v1/Customer/${customer._id}`,
@@ -645,6 +740,37 @@ module.exports = function (createFn, setup, dismantle) {
               item: product._id.toHexString()
             }
           })
+          done()
+        })
+      })
+
+      it('GET /Customer/:id?distinct=age 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer/${customer._id}`,
+          qs: {
+            distinct: 'age'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 0)
+          done()
+        })
+      })
+
+      it('GET /Customer/:id?distinct=comment 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer/${customer._id}`,
+          qs: {
+            distinct: 'comment'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 1)
+          assert.equal(body[0], 'Boo')
           done()
         })
       })
@@ -1069,6 +1195,36 @@ module.exports = function (createFn, setup, dismantle) {
         })
       })
 
+      it('GET /Customer?distinct=age 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer`,
+          qs: {
+            distinct: 'age'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 0)
+          done()
+        })
+      })
+
+      it('GET /Customer?distinct=comment 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer`,
+          qs: {
+            distinct: 'comment'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 0)
+          done()
+        })
+      })
+
       it('GET /Customer/:id 200', (done) => {
         request.get({
           url: `${testUrl}/api/v1/Customer/${customer._id}`,
@@ -1085,6 +1241,36 @@ module.exports = function (createFn, setup, dismantle) {
               item: product._id.toHexString()
             }
           })
+          done()
+        })
+      })
+
+      it('GET /Customer/:id?distinct=age 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer/${customer._id}`,
+          qs: {
+            distinct: 'age'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 0)
+          done()
+        })
+      })
+
+      it('GET /Customer/:id?distinct=comment 200', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer/${customer._id}`,
+          qs: {
+            distinct: 'comment'
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 0)
           done()
         })
       })


### PR DESCRIPTION
This will filter out distinct queries containing a private or protected field. ~~The reason for filtering post-query is to mimic behavior where the field did not exist, which is to return an empty array.~~ As suggested, distinct fields are now verified before querying, thus saving a database call and fields that are filtered out return an empty array, as if the field did not exist.

We should be able to backport this very easily to 2.x, however previous versions would require significantly more effort.

@smirea Can you test the patch on your end?

Closes #252