### PR TITLE
fix(ci): prevent testing everything twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ script:
   - npm run test-ci
 after_script:
   - npm install coveralls@~2.11.0 && cat ./coverage/lcov.info | coveralls
+branches:
+  only:
+    - master


### PR DESCRIPTION
So I just realized we have been building every commit twice.

This will make TravisCI build PRs, subsequent pushes and merges only once.

Credit: http://stackoverflow.com/questions/31882306/how-to-configure-travis-ci-to-build-pull-requests-merges-to-master-w-o-redunda