### PR TITLE
fix(query): leave coordinates array as-is in geo queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "async": "~1.5.0",
+    "is-coordinates": "~1.0.0",
     "lodash": "~4.6.0",
     "mongoose-detective": "~0.1.0",
     "moredots": "~0.1.0",

--- a/src/middleware/prepareQuery.js
+++ b/src/middleware/prepareQuery.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const isCoordinates = require('is-coordinates')
 
 module.exports = function (options) {
   function jsonQueryParser (key, value) {
@@ -23,7 +24,7 @@ module.exports = function (options) {
       } else if (value[0] === '=') {
         return { $eq: value.substr(1) }*/
       }
-    } else if (_.isArray(value) && key[0] !== '$') {
+    } else if (_.isArray(value) && key[0] !== '$' && key !== 'coordinates' && !isCoordinates(value)) {
       return { $in: value }
     }
 

--- a/test/integration/read.js
+++ b/test/integration/read.js
@@ -44,7 +44,8 @@ module.exports = function (createFn, setup, dismantle) {
                 item: createdProduct._id,
                 number: 1
               }
-            }
+            },
+            coordinates: [45.2667, 72.1500]
           }, {
             name: 'John',
             age: 24,
@@ -313,6 +314,31 @@ module.exports = function (createFn, setup, dismantle) {
           assert.ok(!err)
           assert.equal(res.statusCode, 200)
           assert.equal(body.length, 3)
+          done()
+        })
+      })
+
+      it('GET /Customer?query={"$near": { "$geometry": { "coordinates": [45.2667, 72.1500] } }} 200 - coordinates', (done) => {
+        request.get({
+          url: `${testUrl}/api/v1/Customer`,
+          qs: {
+            query: JSON.stringify({
+              coordinates: {
+                $near: {
+                  $geometry: {
+                    type: 'Point',
+                    coordinates: [45.2667, 72.1500]
+                  },
+                  $maxDistance: 1000
+                }
+              }
+            })
+          },
+          json: true
+        }, (err, res, body) => {
+          assert.ok(!err)
+          assert.equal(res.statusCode, 200)
+          assert.equal(body.length, 1)
           done()
         })
       })

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -37,7 +37,8 @@ module.exports = function () {
       }],
       returns: [{ type: Schema.Types.ObjectId, ref: 'Product' }],
       creditCard: { type: String, access: 'protected' },
-      ssn: { type: String, access: 'private' }
+      ssn: { type: String, access: 'private' },
+      coordinates: { type: [Number], index: '2dsphere' }
     })
   }
 


### PR DESCRIPTION
This tries to *guess* if a value being `JSON.parse`'d is likely to be a coordinate. The key must be `coordinates` and the value must be an array of two numbers.

However, I'm not sure if it may cause issues in some cases.

Closes #187 