### PR TITLE
feat(options): add allowRegex

### DIFF
--- a/src/express-restify-mongoose.js
+++ b/src/express-restify-mongoose.js
@@ -14,6 +14,7 @@ function getDefaults () {
     lean: true,
     restify: false,
     runValidators: false,
+    allowRegex: true,
     private: [],
     protected: []
   })

--- a/src/middleware/prepareQuery.js
+++ b/src/middleware/prepareQuery.js
@@ -2,9 +2,13 @@ const _ = require('lodash')
 
 module.exports = function (options) {
   function jsonQueryParser (key, value) {
+    if (key === '$regex' && !options.allowRegex) {
+      return undefined
+    }
+
     if (_.isString(value)) {
       if (value[0] === '~') { // parse RegExp
-        return new RegExp(value.substr(1), 'i')
+        return options.allowRegex ? new RegExp(value.substr(1), 'i') : undefined
       } else if (value[0] === '>') {
         if (value[1] === '=') {
           return { $gte: value.substr(2) }

--- a/test/integration/read.js
+++ b/test/integration/read.js
@@ -387,6 +387,24 @@ module.exports = function (createFn, setup, dismantle) {
           })
         })
 
+        it('GET /Customer?query={"name":{"$regex":"^J"}} 200 - name starting with', (done) => {
+          request.get({
+            url: `${testUrl}/api/v1/Customer`,
+            qs: {
+              query: JSON.stringify({
+                name: { $regex: '^J' }
+              })
+            },
+            json: true
+          }, (err, res, body) => {
+            assert.ok(!err)
+            assert.equal(res.statusCode, 200)
+            assert.equal(body.length, 1)
+            assert.ok(body[0].name[0] === 'J')
+            done()
+          })
+        })
+
         it('GET /Customer?query={"name":">=John"} 200 - greater than or equal', (done) => {
           request.get({
             url: `${testUrl}/api/v1/Customer`,

--- a/test/unit/middleware/prepareQuery.js
+++ b/test/unit/middleware/prepareQuery.js
@@ -5,13 +5,15 @@ describe('prepareQuery', () => {
   const prepareQuery = require('../../../lib/middleware/prepareQuery')
 
   let options = {
-    onError: sinon.spy()
+    onError: sinon.spy(),
+    allowRegex: true
   }
 
   let next = sinon.spy()
 
   afterEach(() => {
     options.onError.reset()
+    options.allowRegex = true
     next.reset()
   })
 
@@ -28,6 +30,46 @@ describe('prepareQuery', () => {
       assert.deepEqual(req._ermQueryOptions, {
         query: {
           foo: new RegExp('bar', 'i')
+        }
+      })
+      sinon.assert.calledOnce(next)
+      sinon.assert.calledWithExactly(next)
+      sinon.assert.notCalled(options.onError)
+    })
+
+    it('converts ~ to undefined', () => {
+      let req = {
+        query: {
+          query: '{"foo":"~bar"}'
+        }
+      }
+
+      options.allowRegex = false
+
+      prepareQuery(options)(req, {}, next)
+
+      assert.deepEqual(req._ermQueryOptions, {
+        query: {}
+      })
+      sinon.assert.calledOnce(next)
+      sinon.assert.calledWithExactly(next)
+      sinon.assert.notCalled(options.onError)
+    })
+
+    it('converts $regex to undefined', () => {
+      let req = {
+        query: {
+          query: '{"foo":{"$regex":"bar"}}'
+        }
+      }
+
+      options.allowRegex = false
+
+      prepareQuery(options)(req, {}, next)
+
+      assert.deepEqual(req._ermQueryOptions, {
+        query: {
+          foo: {}
         }
       })
       sinon.assert.calledOnce(next)


### PR DESCRIPTION
This add an `allowRegex` option that defaults to `true` for backward compatibility. When set to `false`, queries attempting to use a regex (either with `~` or `$regex`) will send back an error.

Closes #195 