### PR TITLE
Update sort documentation

### DIFF
--- a/v2/index.md
+++ b/v2/index.md
@@ -106,7 +106,7 @@ All the following parameters (sort, skip, limit, query, populate, select and dis
 GET /Customers?sort=name
 GET /Customers?sort=-name
 GET /Customers?sort={"name":1}
-GET /Customers?sort={"name":0}
+GET /Customers?sort={"name":-1}
 ```
 
 ### Skip


### PR DESCRIPTION
The documentation says, that `{"key": 0}` is a valid sort object. But its leading to a MongoError "bad sort specification", because the mongodb does only allow `1` or `-1` when specifying the sort order like this: https://docs.mongodb.org/manual/reference/method/cursor.sort/#ascending-descending-sort