### PR TITLE
refactor(ouput): remove undocumented parameter

### DIFF
--- a/src/middleware/prepareOutput.js
+++ b/src/middleware/prepareOutput.js
@@ -47,10 +47,7 @@ module.exports = function (options, excludedMap) {
         res.header(_.isString(options.totalCountHeader) ? options.totalCountHeader : 'X-Total-Count', req.erm.totalCount)
       }
 
-      options.outputFn(req, res, {
-        result: req.erm.result,
-        statusCode: req.erm.statusCode
-      })
+      options.outputFn(req, res)
 
       if (options.postProcess) {
         options.postProcess(req, res, next)

--- a/test/unit/middleware/prepareOutput.js
+++ b/test/unit/middleware/prepareOutput.js
@@ -27,10 +27,7 @@ describe('prepareOutput', () => {
     prepareOutput(options)(req, {}, next)
 
     sinon.assert.calledOnce(outputFn)
-    sinon.assert.calledWithExactly(outputFn, req, {}, {
-      result: undefined,
-      statusCode: undefined
-    })
+    sinon.assert.calledWithExactly(outputFn, req, {})
     sinon.assert.notCalled(onError)
     sinon.assert.notCalled(next)
   })
@@ -58,12 +55,7 @@ describe('prepareOutput', () => {
 
     sinon.assert.calledOnce(postCreate)
     sinon.assert.calledOnce(outputFn)
-    sinon.assert.calledWithExactly(outputFn, req, {}, {
-      result: {
-        name: 'Bob'
-      },
-      statusCode: 201
-    })
+    sinon.assert.calledWithExactly(outputFn, req, {})
     sinon.assert.notCalled(onError)
     sinon.assert.notCalled(next)
   })
@@ -91,12 +83,7 @@ describe('prepareOutput', () => {
 
     sinon.assert.calledOnce(postRead)
     sinon.assert.calledOnce(outputFn)
-    sinon.assert.calledWithExactly(outputFn, req, {}, {
-      result: {
-        name: 'Bob'
-      },
-      statusCode: 200
-    })
+    sinon.assert.calledWithExactly(outputFn, req, {})
     sinon.assert.notCalled(onError)
     sinon.assert.notCalled(next)
   })
@@ -124,12 +111,7 @@ describe('prepareOutput', () => {
 
     sinon.assert.calledOnce(postUpdate)
     sinon.assert.calledOnce(outputFn)
-    sinon.assert.calledWithExactly(outputFn, req, {}, {
-      result: {
-        name: 'Bob'
-      },
-      statusCode: 200
-    })
+    sinon.assert.calledWithExactly(outputFn, req, {})
     sinon.assert.notCalled(onError)
     sinon.assert.notCalled(next)
   })
@@ -157,12 +139,7 @@ describe('prepareOutput', () => {
 
     sinon.assert.calledOnce(postUpdate)
     sinon.assert.calledOnce(outputFn)
-    sinon.assert.calledWithExactly(outputFn, req, {}, {
-      result: {
-        name: 'Bob'
-      },
-      statusCode: 200
-    })
+    sinon.assert.calledWithExactly(outputFn, req, {})
     sinon.assert.notCalled(onError)
     sinon.assert.notCalled(next)
   })
@@ -190,12 +167,7 @@ describe('prepareOutput', () => {
 
     sinon.assert.calledOnce(postDelete)
     sinon.assert.calledOnce(outputFn)
-    sinon.assert.calledWithExactly(outputFn, req, {}, {
-      result: {
-        name: 'Bob'
-      },
-      statusCode: 204
-    })
+    sinon.assert.calledWithExactly(outputFn, req, {})
     sinon.assert.notCalled(onError)
     sinon.assert.notCalled(next)
   })


### PR DESCRIPTION
- Useful in v1.x and earlier
- Removed from documentation since v2.0 in favor of `req.erm.result` and
`req.erm.statusCode`