### PR TITLE
Update express-restify-mongoose.js

### DIFF
--- a/src/express-restify-mongoose.js
+++ b/src/express-restify-mongoose.js
@@ -5,7 +5,7 @@ let customDefaults = null
 let excludedMap = {}
 
 function getDefaults () {
-  return _.defaults(customDefaults || {}, {
+  return _.defaults(_.clone(customDefaults) || {}, {
     prefix: '/api',
     version: '/v1',
     idProperty: '_id',


### PR DESCRIPTION
Added a `_.clone()` because `_.defaults()` mutates the first parameter and return its reference.

Fix #288