### PR TITLE
Drop Node 0.10 & 0.12, add Node 7, update restify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
 services:
   - "mongodb"
 sudo: false

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "standard": "^8.0.0"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=4"
   },
   "homepage": "http://florianholzapfel.github.io/express-restify-mongoose/",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "method-override": "^2.3.0",
     "mocha": "^3.0.0",
     "request": "^2.69.0",
-    "restify": "^3.0.0",
+    "restify": "^4.3.0",
     "sinon": "^1.17.0",
     "standard": "^8.0.0"
   },

--- a/test/integration/create.js
+++ b/test/integration/create.js
@@ -337,14 +337,16 @@ module.exports = function (createFn, setup, dismantle) {
               message: 'Cast to ObjectID failed for value "invalid-id" at path "customer"',
               name: 'CastError',
               path: 'customer',
-              value: 'invalid-id'
+              value: 'invalid-id',
+              stringValue: '"invalid-id"'
             },
             products: {
               kind: 'Array',
               message: 'Cast to Array failed for value "[ \'invalid-id\', \'invalid-id\' ]" at path "products"',
               name: 'CastError',
               path: 'products',
-              value: ['invalid-id', 'invalid-id']
+              value: ['invalid-id', 'invalid-id'],
+              stringValue: `"[ 'invalid-id', 'invalid-id' ]"`
             }
           }
         })

--- a/test/integration/options.js
+++ b/test/integration/options.js
@@ -831,10 +831,11 @@ module.exports = function (createFn, setup, dismantle) {
         assert.equal(res.statusCode, 400)
         assert.deepEqual(body, {
           kind: 'string',
-          message: 'Cast to string failed for value "{}" at path "name"',
+          message: 'Cast to string failed for value "{}" at path "name" for model "Customer"',
           name: 'CastError',
           path: 'name',
-          value: {}
+          value: {},
+          stringValue: `"{}"`
         })
         done()
       })

--- a/test/integration/read.js
+++ b/test/integration/read.js
@@ -599,10 +599,11 @@ module.exports = function (createFn, setup, dismantle) {
             assert.equal(res.statusCode, 400)
             assert.deepEqual(body, {
               kind: 'number',
-              message: 'Cast to number failed for value "/2/i" at path "age"',
+              message: 'Cast to number failed for value "/2/i" at path "age" for model "Customer"',
               name: 'CastError',
               path: 'age',
-              value: {}
+              value: {},
+              stringValue: `"/2/i"`
             })
             done()
           })

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -110,7 +110,8 @@ module.exports = function (createFn, setup, dismantle) {
               message: 'Cast to number failed for value "not a number" at path "age"',
               name: 'CastError',
               path: 'age',
-              value: 'not a number'
+              value: 'not a number',
+              stringValue: `"not a number"`
             })
             done()
           })
@@ -456,7 +457,8 @@ module.exports = function (createFn, setup, dismantle) {
                   message: 'Cast to Number failed for value "not a number" at path "age"',
                   name: 'CastError',
                   path: 'age',
-                  value: 'not a number'
+                  value: 'not a number',
+                  stringValue: `"not a number"`
                 }
               }
             })

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -482,7 +482,6 @@ module.exports = function (createFn, setup, dismantle) {
               name: 'John'
             }
           }, (err, res, body) => {
-            console.log('body', body)
             assert.ok(!err)
             assert.equal(res.statusCode, 400)
             // Remove extra whitespace, allow 8 keys and code 11001 for MongoDB < 3

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -484,8 +484,12 @@ module.exports = function (createFn, setup, dismantle) {
           }, (err, res, body) => {
             assert.ok(!err)
             assert.equal(res.statusCode, 400)
-            // Remove extra whitespace, allow 8 keys and code 11001 for MongoDB < 3
-            assert.ok(Object.keys(body).length === 6 || Object.keys(body).length === 8)
+            // Remove extra whitespace, allow 6, 8, or 9 keys and code 11001 for MongoDB < 3
+            assert.ok(
+              Object.keys(body).length === 6 ||
+              Object.keys(body).length === 8 ||
+              Object.keys(body).length === 9
+            )
             assert.equal(body.name, 'MongoError')
             assert.equal(body.driver, true)
             assert.ok(
@@ -499,6 +503,7 @@ module.exports = function (createFn, setup, dismantle) {
               ) !== null
             )
             assert.ok(body.code === 11000 || body.code === 11001)
+            assert.ok(!body.writeErrors || body.writeErrors.length === 1)
             done()
           })
         })

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -126,12 +126,21 @@ module.exports = function (createFn, setup, dismantle) {
           }, (err, res, body) => {
             assert.ok(!err)
             assert.equal(res.statusCode, 400)
-            assert.equal(Object.keys(body).length, 5)
+            assert.ok(Object.keys(body).length === 5 || Object.keys(body).length === 6)
             assert.equal(body.name, 'MongoError')
             // Remove extra whitespace and allow code 11001 for MongoDB < 3
-            assert.equal(body.errmsg.replace(/\s+/g, ' ').replace('exception: ', ''), 'E11000 duplicate key error index: database.customers.$name_1 dup key: { : "John" }')
-            assert.equal(body.message.replace(/\s+/g, ' ').replace('exception: ', ''), 'E11000 duplicate key error index: database.customers.$name_1 dup key: { : "John" }')
+            assert.ok(
+              body.errmsg.replace(/\s+/g, ' ').replace('exception: ', '').match(
+                /E11000 duplicate key error (?:index|collection): database.customers(\.\$| index: )name_1 dup key: { : "John" }/
+              ) !== null
+            )
+            assert.ok(
+              body.message.replace(/\s+/g, ' ').replace('exception: ', '').match(
+                /E11000 duplicate key error (?:index|collection): database.customers(?:\.\$| index: )name_1 dup key: { : "John" }/
+              ) !== null
+            )
             assert.ok(body.code === 11000 || body.code === 11001)
+            assert.ok(!body.codeName || body.codeName === 'DuplicateKey') // codeName is optional
             assert.equal(body.ok, 0)
             done()
           })
@@ -473,14 +482,23 @@ module.exports = function (createFn, setup, dismantle) {
               name: 'John'
             }
           }, (err, res, body) => {
+            console.log('body', body)
             assert.ok(!err)
             assert.equal(res.statusCode, 400)
             // Remove extra whitespace, allow 8 keys and code 11001 for MongoDB < 3
             assert.ok(Object.keys(body).length === 6 || Object.keys(body).length === 8)
             assert.equal(body.name, 'MongoError')
             assert.equal(body.driver, true)
-            assert.equal(body.errmsg.replace(/\s+/g, ' '), 'E11000 duplicate key error index: database.customers.$name_1 dup key: { : "John" }')
-            assert.equal(body.message.replace(/\s+/g, ' '), 'E11000 duplicate key error index: database.customers.$name_1 dup key: { : "John" }')
+            assert.ok(
+              body.errmsg.replace(/\s+/g, ' ').replace('exception: ', '').match(
+                /E11000 duplicate key error (?:index|collection): database.customers(?:\.\$| index: )name_1 dup key: { : "John" }/
+              ) !== null
+            )
+            assert.ok(
+              body.message.replace(/\s+/g, ' ').replace('exception: ', '').match(
+                /E11000 duplicate key error (?:index|collection): database.customers(?:\.\$| index: )name_1 dup key: { : "John" }/
+              ) !== null
+            )
             assert.ok(body.code === 11000 || body.code === 11001)
             done()
           })


### PR DESCRIPTION
Closes #319

Breaking changes:
- Drop support for Node 0.10 & 0.12
- Update to restify 4, see their [changelog](https://github.com/restify/node-restify/blob/5.x/CHANGES.md#400) for details