### PR TITLE
RFC6902 enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "is-coordinates": "~1.0.0",
     "lodash": "~4.17.0",
     "mongoose-detective": "~0.1.0",
+    "mongoose-json-patch": "^1.1.1",
     "moredots": "~0.1.0",
     "serialize-error": "~2.1.0",
     "weedout": "~0.1.0"
@@ -90,5 +91,5 @@
       "it"
     ]
   },
-  "version": "4.1.3"
+  "version": "4.1.4"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "is-coordinates": "~1.0.0",
     "lodash": "~4.17.0",
     "mongoose-detective": "~0.1.0",
-    "mongoose-json-patch": "^1.1.1",
     "moredots": "~0.1.0",
     "serialize-error": "~2.1.0",
     "weedout": "~0.1.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "model"
   ],
   "license": "MIT",
-  "main": "./lib/express-restify-mongoose",
+  "main": "./src/express-restify-mongoose",
   "name": "express-restify-mongoose",
   "readmeFilename": "README.md",
   "repository": {

--- a/src/express-restify-mongoose.js
+++ b/src/express-restify-mongoose.js
@@ -1,7 +1,6 @@
 const util = require('util')
 const _ = require('lodash')
 const Filter = require('./resource_filter')
-const patcher = require('mongoose-json-patch')
 let customDefaults = null
 let excludedMap = {}
 
@@ -41,7 +40,6 @@ const restify = function (app, model, opts = {}) {
     throw new Error('"options.protected" must be an array of fields')
   }
 
-  model.schema.plugin(patcher)
   model.schema.eachPath((name, path) => {
     if (path.options.access) {
       switch (path.options.access.toLowerCase()) {

--- a/src/express-restify-mongoose.js
+++ b/src/express-restify-mongoose.js
@@ -1,6 +1,7 @@
 const util = require('util')
 const _ = require('lodash')
 const Filter = require('./resource_filter')
+const patcher = require('mongoose-json-patch')
 let customDefaults = null
 let excludedMap = {}
 
@@ -40,6 +41,7 @@ const restify = function (app, model, opts = {}) {
     throw new Error('"options.protected" must be an array of fields')
   }
 
+  model.schema.plugin(patcher)
   model.schema.eachPath((name, path) => {
     if (path.options.access) {
       switch (path.options.access.toLowerCase()) {
@@ -145,7 +147,7 @@ const restify = function (app, model, opts = {}) {
   app.post(uriItem, util.deprecate(prepareQuery, 'express-restify-mongoose: in a future major version, the POST method to update resources will be removed. Use PATCH instead.'), ensureContentType, options.preMiddleware, options.findOneAndUpdate ? [] : filterAndFindById, options.preUpdate, accessMiddleware, ops.modifyObject, prepareOutput)
 
   app.put(uriItem, util.deprecate(prepareQuery, 'express-restify-mongoose: in a future major version, the PUT method will replace rather than update a resource. Use PATCH instead.'), ensureContentType, options.preMiddleware, options.findOneAndUpdate ? [] : filterAndFindById, options.preUpdate, accessMiddleware, ops.modifyObject, prepareOutput)
-  app.patch(uriItem, prepareQuery, ensureContentType, options.preMiddleware, options.findOneAndUpdate ? [] : filterAndFindById, options.preUpdate, accessMiddleware, ops.modifyObject, prepareOutput)
+  app.patch(uriItem, prepareQuery, ensureContentType, options.preMiddleware, filterAndFindById, options.preUpdate, accessMiddleware, ops.patchObject, prepareOutput)
 
   app.delete(uriItems, prepareQuery, options.preMiddleware, options.preDelete, ops.deleteItems, prepareOutput)
   app.delete(uriItem, prepareQuery, options.preMiddleware, options.findOneAndRemove ? [] : filterAndFindById, options.preDelete, ops.deleteItem, prepareOutput)

--- a/src/middleware/ensureContentType.js
+++ b/src/middleware/ensureContentType.js
@@ -8,7 +8,8 @@ module.exports = function (options) {
       return errorHandler(req, res, next)(new Error('missing_content_type'))
     }
 
-    if (ct.indexOf('application/json') === -1) {
+    if (ct.indexOf('application/json') === -1 && 
+      (ct.indexOf('application/json-patch+json') === -1 || req.method !== 'PATCH')) {
       return errorHandler(req, res, next)(new Error('invalid_content_type'))
     }
 


### PR DESCRIPTION
I implemented RFC6902 as suggested in the #224 issue.
Some caveats:

1. [mongoose-json-patch](https://www.npmjs.com/package/mongoose-json-patch) must be pluged by the user in schema definition. I tried to plug it addressing model.schema inside express-restify-mongoose module without success.
2. The structure of this module is a chain of middlewares and it was too hard for me to distinguish the behavior between PATCH with application/json and the one with application/json-patch+json. So in my implementation PATCH with application/json doesn't use findOneAndUpdate even if the correspondent option is true because I needed to run the filterAndFindById instead.
3. To use this implementation bodyParser.json has to accept application/json-patch+json content type as well so in the application must be declared something like:
_router.use (bodyParser.json({strict:false, type: (req) => {
  var ct = req.headers['content-type'];
  return (ct === 'application/json-patch+json') || (ct === 'application/json');
}}));_
otherwise req.body will be empty and won't be applied any patch.