### PR TITLE
Added the ability to set totalCountHeader on a specific request

### DIFF
--- a/src/operations.js
+++ b/src/operations.js
@@ -28,10 +28,19 @@ module.exports = function (model, options, excludedMap) {
 
     options.contextFilter(model, req, (filteredContext) => {
       buildQuery(filteredContext.find(), req._ermQueryOptions).then((items) => {
+        var totalCountHeader;
         req.erm.result = items
         req.erm.statusCode = 200
 
-        if (options.totalCountHeader && !req._ermQueryOptions['distinct']) {
+        if (req.query.totalCountHeader === 'true') {
+          totalCountHeader = true;
+        } else if (req.query.totalCountHeader === 'false') {
+          totalCountHeader = false;
+        } else {
+          totalCountHeader = options.totalCountHeader;
+        }
+
+        if (totalCountHeader && !req._ermQueryOptions['distinct']) {
           options.contextFilter(model, req, (countFilteredContext) => {
             buildQuery(countFilteredContext.count(), _.assign(req._ermQueryOptions, {
               skip: 0,


### PR DESCRIPTION
The point of this is to be able to set totalCountHeader on specific requests. We have been dealing with larger collections where some of the queries count is not performant, and do not want it to run on. 