### PR TITLE
Add calling next for Adding next() call to prepareOutput middleware […

### DIFF
--- a/src/middleware/prepareOutput.js
+++ b/src/middleware/prepareOutput.js
@@ -50,14 +50,20 @@ module.exports = function (options, excludedMap) {
         if (promise && typeof promise.then === 'function') {
           promise.then(() => {
             options.postProcess(req, res);
-            next();
+            if (options.restify) {
+              next();
+            }
           }).catch(errorHandler(req, res, next))
         } else {
           options.postProcess(req, res);
-          next();
+          if (options.restify) {
+            next();
+          }
         }
       } else {
-        next();
+        if (options.restify) {
+          next();
+        }
       }
     }
 

--- a/src/middleware/prepareOutput.js
+++ b/src/middleware/prepareOutput.js
@@ -49,11 +49,15 @@ module.exports = function (options, excludedMap) {
       if (options.postProcess) {
         if (promise && typeof promise.then === 'function') {
           promise.then(() => {
-            options.postProcess(req, res)
+            options.postProcess(req, res);
+            next();
           }).catch(errorHandler(req, res, next))
         } else {
-          options.postProcess(req, res)
+          options.postProcess(req, res);
+          next();
         }
+      } else {
+        next();
       }
     }
 

--- a/test/unit/middleware/prepareOutput.js
+++ b/test/unit/middleware/prepareOutput.js
@@ -17,6 +17,7 @@ describe('prepareOutput', () => {
     onError.reset()
     outputFn.reset()
     outputFnPromise.reset()
+    postProcess.reset()
     next.reset()
   })
 
@@ -39,7 +40,27 @@ describe('prepareOutput', () => {
     sinon.assert.notCalled(next)
   })
 
-  it('calls outputFn with default options and no post* middleware (async)', () => {
+  it('calls outputFn with default options and no post* middleware and next when restify option', () => {
+    let req = {
+      method: 'GET',
+      erm: {}
+    }
+
+    let options = {
+      restify: true,
+      onError: onError,
+      outputFn: outputFn
+    }
+
+    prepareOutput(options)(req, {}, next)
+
+    sinon.assert.calledOnce(outputFn)
+    sinon.assert.calledWithExactly(outputFn, req, {})
+    sinon.assert.notCalled(onError)
+    sinon.assert.calledOnce(next)
+  })
+
+  it('calls outputFn with default options and no post* middleware (async)', (done) => {
     let req = {
       method: 'GET',
       erm: {}
@@ -52,10 +73,37 @@ describe('prepareOutput', () => {
 
     prepareOutput(options)(req, {}, next)
 
-    sinon.assert.calledOnce(outputFnPromise)
-    sinon.assert.calledWithExactly(outputFnPromise, req, {})
-    sinon.assert.notCalled(onError)
-    sinon.assert.notCalled(next)
+    outputFnPromise().then(() => {
+      sinon.assert.calledTwice(outputFnPromise)
+      sinon.assert.calledWithExactly(outputFnPromise, req, {})
+      sinon.assert.notCalled(onError)
+      sinon.assert.notCalled(next)
+      done()
+    })
+
+  })
+
+  it('calls outputFn with default options and no post* middleware and next when restify option (async)', (done) => {
+    let req = {
+      method: 'GET',
+      erm: {}
+    }
+
+    let options = {
+      restify: true,
+      onError: onError,
+      outputFn: outputFnPromise
+    }
+
+    prepareOutput(options)(req, {}, next)
+
+    outputFnPromise().then(() => {
+      sinon.assert.calledTwice(outputFnPromise)
+      sinon.assert.calledWithExactly(outputFnPromise, req, {})
+      sinon.assert.notCalled(onError)
+      sinon.assert.calledOnce(next)
+      done()
+    });
   })
 
   it('calls postProcess with default options and no post* middleware', () => {
@@ -80,7 +128,30 @@ describe('prepareOutput', () => {
     sinon.assert.notCalled(next)
   })
 
-  it('calls postProcess with default options and no post* middleware (async outputFn)', () => {
+  it('calls postProcess with default options and no post* middleware and next when restify option', () => {
+    let req = {
+      method: 'GET',
+      erm: {}
+    }
+
+    let options = {
+      restify: true,
+      onError: onError,
+      outputFn: outputFn,
+      postProcess: postProcess
+    }
+
+    prepareOutput(options)(req, {}, next)
+
+    sinon.assert.calledOnce(outputFn)
+    sinon.assert.calledWithExactly(outputFn, req, {})
+    sinon.assert.calledOnce(postProcess)
+    sinon.assert.calledWithExactly(postProcess, req, {})
+    sinon.assert.notCalled(onError)
+    sinon.assert.calledOnce(next)
+  })
+
+  it('calls postProcess with default options and no post* middleware (async)', (done) => {
     let req = {
       method: 'GET',
       erm: {}
@@ -94,11 +165,40 @@ describe('prepareOutput', () => {
 
     prepareOutput(options)(req, {}, next)
 
-    sinon.assert.calledOnce(outputFnPromise)
-    sinon.assert.calledWithExactly(outputFnPromise, req, {})
-    sinon.assert.calledOnce(postProcess)
-    sinon.assert.calledWithExactly(postProcess, req, {})
-    sinon.assert.notCalled(onError)
-    sinon.assert.notCalled(next)
+    outputFnPromise().then(() => {
+      sinon.assert.calledTwice(outputFnPromise)
+      sinon.assert.calledWithExactly(outputFnPromise, req, {})
+      sinon.assert.calledOnce(postProcess)
+      sinon.assert.calledWithExactly(postProcess, req, {})
+      sinon.assert.notCalled(onError)
+      sinon.assert.notCalled(next)
+      done()
+    });
+  })
+
+  it('calls postProcess with default options and no post* middleware and next with restify option (async)', (done) => {
+    let req = {
+      method: 'GET',
+      erm: {}
+    }
+
+    let options = {
+      restify: true,
+      onError: onError,
+      outputFn: outputFnPromise,
+      postProcess: postProcess
+    }
+
+    prepareOutput(options)(req, {}, next)
+
+    outputFnPromise().then(() => {
+      sinon.assert.calledTwice(outputFnPromise)
+      sinon.assert.calledWithExactly(outputFnPromise, req, {})
+      sinon.assert.calledOnce(postProcess)
+      sinon.assert.calledWithExactly(postProcess, req, {})
+      sinon.assert.notCalled(onError)
+      sinon.assert.calledOnce(next)
+      done()
+    });
   })
 })


### PR DESCRIPTION
…florianholzapfel/express-restify-mongoose#337]

This fixes an issue whereby any middleware registered to occur after would not be called.  The specific situation which we have which triggers this is a call to server.on('after', <middleware>) where server is a restify server instance.  The specified middleware will never be called without this fix.

I notice that you have specific unit tests to ensure that next is not called from prepareOutput.  If you would like to not merge this PR instead of changing those tests, could you please explain the reasoning for this?  Also, the latest version removed the next parameter from being passed to the postProcess optional parameter which prevents an easy work-around for this not being called in prepareOutput.
