### PR TITLE
Allow upsert on PUT

### DIFF
--- a/src/express-restify-mongoose.js
+++ b/src/express-restify-mongoose.js
@@ -19,7 +19,8 @@ function getDefaults() {
     runValidators: false,
     allowRegex: true,
     private: [],
-    protected: []
+    protected: [],
+    upsert: false
   })
 }
 

--- a/src/operations.js
+++ b/src/operations.js
@@ -236,6 +236,7 @@ module.exports = function(model, options, excludedMap) {
             },
             {
               new: true,
+              upsert: options.upsert,
               runValidators: options.runValidators
             }
           )


### PR DESCRIPTION
Some use-cases desire PUT to also create a resources, e.g., when the ID is client-controlled. In such cases, the PUT operation should create a resource if it does not exists. This is called `upsert` in MongoDB. This PR adds an options for that.