### PR TITLE
Show totalCount even when it's 0.

### DIFF
--- a/src/middleware/prepareOutput.js
+++ b/src/middleware/prepareOutput.js
@@ -40,7 +40,7 @@ module.exports = function(options, excludedMap) {
         req.erm.result = options.filter ? options.filter.filterObject(req.erm.result, opts) : req.erm.result
       }
 
-      if (options.totalCountHeader && req.erm.totalCount) {
+      if (options.totalCountHeader && req.erm.totalCount !== "undefined") {
         res.header(typeof options.totalCountHeader === 'string' ? options.totalCountHeader : 'X-Total-Count', req.erm.totalCount)
       }
 


### PR DESCRIPTION
Because of the condition `if (options.totalCountHeader && req.erm.totalCount)`, a total count of will never be put in the header if no data is returned since 0 is evaluated as false.

This can be problematic with some client implementations which use this header to know if data is present or not.