### PR TITLE
passing request object to getModel in modelFactory

### DIFF
--- a/src/express-restify-mongoose.js
+++ b/src/express-restify-mongoose.js
@@ -111,7 +111,7 @@ const restify = function (app, model, opts) {
     const getModel = options.modelFactory && options.modelFactory.getModel
 
     req.erm = {
-      model: typeof getModel === 'function' ? getModel() : model,
+      model: typeof getModel === 'function' ? getModel(req) : model,
     }
 
     next()


### PR DESCRIPTION
Simple enhancement: When the function getModel() is called, the request is passed as call arg. 

@Zertz : I haven't seen any tests for the model factory right now. If any, I would place them in the /test/integrations/options.js file. If there is any interest, I would submit them in a different PR. Your opinion?

BTW: modelFactory is not yet registered in index.d.ts. Is there a special reason?