### PR TITLE
Mongoose 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "weedout": "~1.0.1"
   },
   "peerDependencies": {
-    "mongoose": "^5.8.10"
+    "mongoose": "^6.2.1"
   },
   "description": "Easily create a flexible REST interface for mongoose models",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "weedout": "~1.0.1"
   },
   "peerDependencies": {
-    "mongoose": "^6.2.1"
+    "mongoose": "6.x"
   },
   "description": "Easily create a flexible REST interface for mongoose models",
   "devDependencies": {

--- a/src/middleware/prepareQuery.js
+++ b/src/middleware/prepareQuery.js
@@ -70,6 +70,14 @@ module.exports = function (options) {
       } else if (!Array.isArray(queryOptions.populate)) {
         queryOptions.populate = [queryOptions.populate]
       }
+
+      // Configure populate query to not use strict populate to maintain
+      // behavior from Mongoose previous to v6 (unless already configured).
+      queryOptions.populate = queryOptions.populate.map((pop) => {
+        if (pop.strictPopulate !== undefined) return pop
+        pop.strictPopulate = false
+        return pop
+      })
     }
 
     return queryOptions

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -5,11 +5,6 @@ const mongoose = require('mongoose')
 const Schema = mongoose.Schema
 const util = require('util')
 
-mongoose.set('useNewUrlParser', true)
-mongoose.set('useFindAndModify', false)
-mongoose.set('useCreateIndex', true)
-mongoose.set('useUnifiedTopology', true)
-
 module.exports = function () {
   const ProductSchema = new Schema({
     name: { type: String, required: true },

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -171,14 +171,8 @@ module.exports = function (createFn, setup, dismantle) {
               assert.ok(!err)
               assert.equal(res.statusCode, 400)
               assert.ok(Object.keys(body).length === 5 || Object.keys(body).length === 6 || Object.keys(body).length === 8)
-              assert.equal(body.name, 'MongoError')
+              assert.equal(body.name, 'MongoServerError')
               // Remove extra whitespace and allow code 11001 for MongoDB < 3
-              assert.ok(
-                body.errmsg
-                  .replace(/\s+/g, ' ')
-                  .replace('exception: ', '')
-                  .match(/E11000 duplicate key error (?:index|collection): database.customers(\.\$| index: )name_1 dup key: { (?:name|): "John" }/) !== null
-              )
               assert.ok(
                 body.message
                   .replace(/\s+/g, ' ')
@@ -659,14 +653,7 @@ module.exports = function (createFn, setup, dismantle) {
               assert.equal(res.statusCode, 400)
               // Remove extra whitespace, allow 6, 8, or 9 keys and code 11001 for MongoDB < 3
               assert.ok(Object.keys(body).length === 6 || Object.keys(body).length === 8 || Object.keys(body).length === 9)
-              assert.equal(body.name, 'MongoError')
-              assert.equal(body.driver, true)
-              assert.ok(
-                body.errmsg
-                  .replace(/\s+/g, ' ')
-                  .replace('exception: ', '')
-                  .match(/E11000 duplicate key error (?:index|collection): database.customers(?:\.\$| index: )name_1 dup key: { (?:name|): "John" }/) !== null
-              )
+              assert.equal(body.name, 'MongoServerError')
               assert.ok(
                 body.message
                   .replace(/\s+/g, ' ')

--- a/test/unit/middleware/prepareQuery.js
+++ b/test/unit/middleware/prepareQuery.js
@@ -206,6 +206,7 @@ describe('prepareQuery', () => {
       populate: [
         {
           path: 'foo',
+          strictPopulate: false,
         },
       ],
     })
@@ -328,6 +329,7 @@ describe('prepareQuery', () => {
         populate: [
           {
             path: 'foo',
+            strictPopulate: false,
           },
         ],
       })
@@ -349,9 +351,11 @@ describe('prepareQuery', () => {
         populate: [
           {
             path: 'foo',
+            strictPopulate: false,
           },
           {
             path: 'bar',
+            strictPopulate: false,
           },
         ],
       })
@@ -381,6 +385,7 @@ describe('prepareQuery', () => {
             select: 'baz',
             match: { qux: 'quux' },
             options: { sort: 'baz' },
+            strictPopulate: false,
           },
         ],
       })
@@ -404,6 +409,7 @@ describe('prepareQuery', () => {
           {
             path: 'foo',
             select: 'bar baz',
+            strictPopulate: false,
           },
         ],
       })


### PR DESCRIPTION
This updates the peer dependency of mongoose to v6.2.1 and fixes the following migration issues:

- Maintains the previous behaviour where unrecognized paths was set to be populated, i.e. the population is simply ignored. The [new behavior in Mongoose 6](https://mongoosejs.com/docs/migrating_to_6.html#strictpopulate) is to return an error unless `strictPopulate: false` is used as an option. prepareQuery.js is updated to add this option.
- Tests are updated to [reflect the change](https://mongoosejs.com/docs/migrating_to_6.html#mongoerror-is-now-mongoservererror) from `MongoError` to `MongoServerError`
- [Deprecated Mongoose options](https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options) are removed from the tests.

Fixes issue #432

_**Note:** I encountered some existing test errors. I did not address them in this PR but rather fixed additional failing tests caused by the Mongoose 6 update._