### PR TITLE
Fix support for modelFactory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-restify-mongoose",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Easily create a flexible REST interface for mongoose models",
   "keywords": [
     "ReST",

--- a/src/express-restify-mongoose.ts
+++ b/src/express-restify-mongoose.ts
@@ -96,9 +96,13 @@ export function serve(
     app.delete = app.del;
   }
 
-  app.use((req, res, next) => {
-    req.erm = {};
-
+  app.use(async (req, res, next) => {
+    const getModel = serveOptions?.modelFactory?.getModel;
+    
+    req.erm = {
+      model: typeof getModel === 'function' ? await getModel(req) : model,
+    };
+    
     next();
   });
 


### PR DESCRIPTION
I don't know where it got lost, but I think back when ERM 8 got released, we lost the changes introduced by #420.

This PR adds them back (allowing for multi tenancy again #393) and also optionally allows getModel to be async (or return a Promise), so that apps using it don't have to operate synchronously.
