### PR TITLE
Fix a modelFactory bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-restify-mongoose",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Easily create a flexible REST interface for mongoose models",
   "keywords": [
     "ReST",

--- a/src/express-restify-mongoose.ts
+++ b/src/express-restify-mongoose.ts
@@ -96,7 +96,8 @@ export function serve(
     app.delete = app.del;
   }
 
-  app.use(async (req, res, next) => {
+  // @ts-expect-error restify
+  const modelMiddleware = async (req, res, next) => {
     const getModel = serveOptions?.modelFactory?.getModel;
     
     req.erm = {
@@ -104,7 +105,7 @@ export function serve(
     };
     
     next();
-  });
+  };
 
   const accessMiddleware = serveOptions.access
     ? getAccessHandler({
@@ -115,7 +116,7 @@ export function serve(
     : [];
 
   const ensureContentType = getEnsureContentTypeHandler(serveOptions);
-  const filterAndFindById = getFilterAndFindByIdHandler(serveOptions, model);
+  const filterAndFindById = getFilterAndFindByIdHandler(serveOptions);
   const prepareQuery = getPrepareQueryHandler(serveOptions);
   const prepareOutput = getPrepareOutputHandler(
     serveOptions,
@@ -125,6 +126,7 @@ export function serve(
 
   app.get(
     uriItems,
+    modelMiddleware,
     prepareQuery,
     serveOptions.preMiddleware,
     serveOptions.preRead,
@@ -135,6 +137,7 @@ export function serve(
 
   app.get(
     uriCount,
+    modelMiddleware,
     prepareQuery,
     serveOptions.preMiddleware,
     serveOptions.preRead,
@@ -145,6 +148,7 @@ export function serve(
 
   app.get(
     uriItem,
+    modelMiddleware,
     prepareQuery,
     serveOptions.preMiddleware,
     serveOptions.preRead,
@@ -155,6 +159,7 @@ export function serve(
 
   app.get(
     uriShallow,
+    modelMiddleware,
     prepareQuery,
     serveOptions.preMiddleware,
     serveOptions.preRead,
@@ -165,6 +170,7 @@ export function serve(
 
   app.post(
     uriItems,
+    modelMiddleware,
     prepareQuery,
     ensureContentType,
     serveOptions.preMiddleware,
@@ -176,6 +182,7 @@ export function serve(
 
   app.post(
     uriItem,
+    modelMiddleware,
     deprecate(
       prepareQuery,
       "express-restify-mongoose: in a future major version, the POST method to update resources will be removed. Use PATCH instead."
@@ -191,6 +198,7 @@ export function serve(
 
   app.put(
     uriItem,
+    modelMiddleware,
     deprecate(
       prepareQuery,
       "express-restify-mongoose: in a future major version, the PUT method will replace rather than update a resource. Use PATCH instead."
@@ -206,6 +214,7 @@ export function serve(
 
   app.patch(
     uriItem,
+    modelMiddleware,
     prepareQuery,
     ensureContentType,
     serveOptions.preMiddleware,
@@ -218,6 +227,7 @@ export function serve(
 
   app.delete(
     uriItems,
+    modelMiddleware,
     prepareQuery,
     serveOptions.preMiddleware,
     serveOptions.preDelete,
@@ -227,6 +237,7 @@ export function serve(
 
   app.delete(
     uriItem,
+    modelMiddleware,
     prepareQuery,
     serveOptions.preMiddleware,
     serveOptions.findOneAndRemove ? [] : filterAndFindById,

--- a/src/middleware/filterAndFindById.ts
+++ b/src/middleware/filterAndFindById.ts
@@ -8,13 +8,15 @@ export function getFilterAndFindByIdHandler(
   options: Pick<
     Options,
     "contextFilter" | "idProperty" | "onError" | "readPreference"
-  >,
-  model: mongoose.Model<unknown>
+  >
 ) {
   const errorHandler = getErrorHandler(options);
 
   const fn: RequestHandler = function filterAndFindById(req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     if (!req.params.id) {
       return next();

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -51,7 +51,10 @@ export function operations(
   }
 
   const getItems: RequestHandler = function (req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     if (isDistinctExcluded(req)) {
       req.erm.result = [];
@@ -91,7 +94,10 @@ export function operations(
   };
 
   const getCount: RequestHandler = function (req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     options.contextFilter(contextModel, req, (filteredContext) => {
       buildQuery(filteredContext.countDocuments(), req.erm.query)
@@ -106,7 +112,10 @@ export function operations(
   };
 
   const getShallow: RequestHandler = function (req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     options.contextFilter(contextModel, req, (filteredContext) => {
       buildQuery<Record<string, unknown> | null>(
@@ -136,7 +145,10 @@ export function operations(
   };
 
   const deleteItems: RequestHandler = function (req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     options.contextFilter(contextModel, req, (filteredContext) => {
       buildQuery(filteredContext.deleteMany(), req.erm.query)
@@ -150,7 +162,10 @@ export function operations(
   };
 
   const getItem: RequestHandler = function (req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     if (isDistinctExcluded(req)) {
       req.erm.result = [];
@@ -179,7 +194,10 @@ export function operations(
   };
 
   const deleteItem: RequestHandler = function (req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     if (options.findOneAndRemove) {
       options.contextFilter(contextModel, req, (filteredContext) => {
@@ -210,7 +228,10 @@ export function operations(
   };
 
   const createObject: RequestHandler = function (req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     req.body = filter.filterObject(req.body || {}, {
       access: req.access,
@@ -245,7 +266,10 @@ export function operations(
   };
 
   const modifyObject: RequestHandler = function (req, res, next) {
-    const contextModel = model;
+    const contextModel = req.erm.model;
+    if (!contextModel) {
+      return errorHandler(new Error('Model is undefined.'), req, res, next);
+    }
 
     req.body = filter.filterObject(req.body || {}, {
       access: req.access,
@@ -266,6 +290,7 @@ export function operations(
       const dst: Record<string, unknown> = {};
 
       for (const [key, value] of Object.entries(src)) {
+        // @ts-expect-error this is fine 🐶🔥
         const path = contextModel.schema.path(key);
 
         // @ts-expect-error this is fine 🐶🔥


### PR DESCRIPTION
I found another bug regarding the modelFactory. Many places in the code were exclusively using the initially provided model instead of the model dynamically provided through modelfactory.getModel.

As we don't have any integration tests for this feature, I created a little test script to verify that it works as expected:

``` JavaScript
var express = require('express')
var bodyParser = require('body-parser')
var methodOverride = require('method-override')
var mongoose = require('mongoose')
var restify = require('express-restify-mongoose')
const request = require('request-promise')
var app = express()
var router = express.Router()

app.use(bodyParser.json())
app.use(methodOverride())

mongoose.connect('mongodb://localhost/database')

var customerSchema = new mongoose.Schema({
  name: { type: String, required: true },
  comment: { type: String }
})
var userSchema = new mongoose.Schema({
  name: { type: String },
  email: { type: String, required: true }
})

var customerModel = mongoose.model('Customer', customerSchema)
var userModel = mongoose.model('User', userSchema)

restify.serve(router, customerModel, {
  modelFactory: {
    getModel: async (req) => {
      return null // THIS IS EXPECTED TO FAIL
    }
  }
})

restify.serve(router, userModel, {
  modelFactory: {
    getModel: async (req) => {
      return userModel // THIS IS EXPECTED TO WORK
    }
  }
})

app.use(router)

app.listen(3000, async () => {
  try {
    // GET http://localhost:3000/api/v1/User should work
    await testEndpoint('http://localhost:3000/api/v1/User', 200);
    // GET http://localhost:3000/api/v1/Customer should return an error
    await testEndpoint('http://localhost:3000/api/v1/Customer', 400);
    console.log("Success!")
    process.exit(0)
  } catch (e) {
    console.log(e)
    console.log("Failed!")
    process.exit(1)
  }
})

async function testEndpoint(url, expectedStatus) {
  let res = null
  try {
    res = await request({url, resolveWithFullResponse: true})
  } catch (error) {
    res = error
  }
  if (res.statusCode !== expectedStatus)
    throw new Error(`${url} did not return expected status code. Got "${res.statusCode}" instead of "${expectedStatus} - Error: ${res.error}"`)
  else
    console.log(`${url} is behaving as expected.`)
}
```

We should turn this into an integration test at some point to avoid bugs like this in the future.