### PR TITLE
Enable nested populate query again.

### DIFF
--- a/src/getQuerySchema.ts
+++ b/src/getQuerySchema.ts
@@ -5,6 +5,7 @@ const PopulateOptionsSchema = z.object({
   match: z.record(z.unknown()).optional(),
   options: z.record(z.unknown()).optional(),
   select: z.string().optional(),
+  populate: z.record(z.unknown()).optional(),
   // Configure populate query to not use strict populate to maintain
   // behavior from Mongoose previous to v6 (unless already configured)
   strictPopulate: z.boolean().optional().default(false),


### PR DESCRIPTION
The populate option in the populate query was enabled by default in previous version the project.
But recent version is not containing the nested populate option in the PopulateOptionsSchema. 
Because of this absence, the query with nested populate option like below is not working properly.

`populate=[{"path":"course", "populate":{"path":"badge"}}]`

By adding the property for the nested populate definition, the query with nested popluate working well.

